### PR TITLE
Fix: Ensure Payment Gateway Settings are Saved Correctly

### DIFF
--- a/src/hooks/usePaymentGatewaySettings.ts
+++ b/src/hooks/usePaymentGatewaySettings.ts
@@ -1,12 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 
+/**
+ * @description Hook to fetch the current payment gateway settings from the database.
+ * This hook is intended for client-side use to determine if the payment UI should be enabled
+ * and which gateway is active. It does NOT expose any secret keys.
+ *
+ * @returns An object with:
+ *  - `enabled`: A boolean indicating if the payment system is turned on. Defaults to `false`.
+ *  - `activeGateway`: The identifier for the active payment gateway (e.g., 'stripe'). Defaults to 'stripe'.
+ */
 export const usePaymentGatewaySettings = () => {
   return useQuery({
     queryKey: ['payment-gateway-settings'],
     queryFn: async () => {
       try {
-        // Check for payment gateway settings first
         const { data: gatewayData, error: gatewayError } = await supabase
           .from('system_settings')
           .select('value')
@@ -14,8 +22,9 @@ export const usePaymentGatewaySettings = () => {
           .maybeSingle();
 
         if (gatewayError && gatewayError.code !== 'PGRST116') {
+          // PGRST116 is the error code for "Not Found", which is expected if settings are not yet saved.
           console.error('Error fetching payment gateway settings:', gatewayError);
-          return { enabled: false }; // Default to disabled if we can't fetch
+          return { enabled: false, activeGateway: 'stripe' };
         }
 
         if (gatewayData?.value) {
@@ -26,13 +35,17 @@ export const usePaymentGatewaySettings = () => {
           };
         }
 
-        // If no settings are found, or if the value is null, default to disabled.
-        return { enabled: false };
+        // If no settings row is found, or if the value is null, default to disabled.
+        // This is a safe default to prevent users from attempting payments if the system isn't configured.
+        return { enabled: false, activeGateway: 'stripe' };
       } catch (error) {
-        console.error('Error in useStripeSettings:', error);
-        return { enabled: false };
+        console.error('Error in usePaymentGatewaySettings:', error);
+        // In case of any unexpected error, default to disabled for safety.
+        return { enabled: false, activeGateway: 'stripe' };
       }
     },
-    staleTime: 5 * 60 * 1000, // 5 minutes
+    // Cache the settings for 5 minutes to reduce unnecessary database calls.
+    // The settings are not expected to change frequently for a single user session.
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/supabase/functions/create-payment/index.ts
+++ b/supabase/functions/create-payment/index.ts
@@ -57,11 +57,15 @@ serve(async (req) => {
       .eq('key', 'payment_gateway_settings')
       .single();
 
-    if (settingsError) throw new Error('Could not load payment settings.');
+    if (settingsError) {
+      console.error("Error loading payment settings:", settingsError);
+      throw new Error('Could not load system payment settings.');
+    }
+    if (!settingsData?.value) {
+      throw new Error('Payment settings are not configured in the system.');
+    }
 
     const settings = settingsData.value as PaymentGatewaySettings;
-    console.log("DEBUG: Full settings object from DB:", JSON.stringify(settings, null, 2));
-
     const { amount, credits, description, packId } = await req.json();
 
     if (!amount || !credits || amount <= 0 || credits <= 0) {
@@ -79,7 +83,9 @@ serve(async (req) => {
     // --- Stripe Payment Flow ---
     if (settings.activeGateway === 'stripe') {
       const stripeKeys = settings.mode === 'live' ? settings.stripe.live : settings.stripe.test;
-      if (!stripeKeys.secretKey) throw new Error(`Stripe ${settings.mode} secret key is not configured.`);
+      if (!stripeKeys?.secretKey) {
+        throw new Error(`Stripe secret key for ${settings.mode} mode is not configured.`);
+      }
 
       const stripe = new Stripe(stripeKeys.secretKey, { apiVersion: "2023-10-16" });
 
@@ -112,11 +118,10 @@ serve(async (req) => {
 
     // --- Paystack Payment Flow ---
     if (settings.activeGateway === 'paystack') {
-      console.log(`DEBUG: Paystack flow initiated. Mode: ${settings.mode}`);
       const paystackKeys = settings.mode === 'live' ? settings.paystack.live : settings.paystack.test;
-      console.log("DEBUG: Selected Paystack keys:", JSON.stringify(paystackKeys, null, 2));
-
-      if (!paystackKeys.secretKey) throw new Error(`Paystack ${settings.mode} secret key is not configured.`);
+      if (!paystackKeys?.secretKey) {
+        throw new Error(`Paystack secret key for ${settings.mode} mode is not configured.`);
+      }
 
       const paystack = new PaystackClient(paystackKeys.secretKey);
       const tx = await paystack.initTransaction({


### PR DESCRIPTION
This commit fixes a critical issue where the admin panel was not reliably saving payment gateway settings to the Supabase backend. This caused user-facing problems where payments and subscriptions would fail because the client could not fetch the correct configuration.

The fix includes several improvements:

1.  **Improved Admin Panel UX (`PaymentGatewayManagement.tsx`):**
    *   Changes to the "Enable", "Active Gateway", and "Operating Mode" controls are now saved immediately.
    *   A "dirty" state has been added for the API key fields, and the "Save API Keys" button is only enabled when there are unsaved changes.

2.  **Enhanced Client-Side Hook (`usePaymentGatewaySettings.ts`):**
    *   Added detailed comments to the hook to improve maintainability.

3.  **Robust Supabase Functions (`create-payment` and `create-subscription`):**
    *   Added checks to the backend functions to verify that payment settings and the necessary API keys are configured before attempting to process transactions.
    *   Removed debugging `console.log` statements.