### PR TITLE
refactor: Improve type safety of payment settings hook

### DIFF
--- a/src/hooks/usePaymentGatewaySettings.ts
+++ b/src/hooks/usePaymentGatewaySettings.ts
@@ -2,16 +2,24 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 
 /**
+ * @description Defines the client-safe settings for the payment gateway.
+ */
+interface PaymentGatewayClientSettings {
+  enabled: boolean;
+  activeGateway: 'stripe' | 'paystack';
+}
+
+/**
  * @description Hook to fetch the current payment gateway settings from the database.
  * This hook is intended for client-side use to determine if the payment UI should be enabled
  * and which gateway is active. It does NOT expose any secret keys.
  *
  * @returns An object with:
  *  - `enabled`: A boolean indicating if the payment system is turned on. Defaults to `false`.
- *  - `activeGateway`: The identifier for the active payment gateway (e.g., 'stripe'). Defaults to 'stripe'.
+ *  - `activeGateway`: The identifier for the active payment gateway. Defaults to 'paystack'.
  */
 export const usePaymentGatewaySettings = () => {
-  return useQuery({
+  return useQuery<PaymentGatewayClientSettings>({
     queryKey: ['payment-gateway-settings'],
     queryFn: async () => {
       try {
@@ -24,24 +32,27 @@ export const usePaymentGatewaySettings = () => {
         if (gatewayError && gatewayError.code !== 'PGRST116') {
           // PGRST116 is the error code for "Not Found", which is expected if settings are not yet saved.
           console.error('Error fetching payment gateway settings:', gatewayError);
-          return { enabled: false, activeGateway: 'stripe' };
+          return { enabled: false, activeGateway: 'paystack' };
         }
 
         if (gatewayData?.value) {
           const settings = gatewayData.value as { enabled?: boolean; activeGateway?: string };
+          const active = settings.activeGateway;
+          const activeGateway: 'stripe' | 'paystack' = active === 'stripe' ? 'stripe' : 'paystack';
+
           return { 
             enabled: settings.enabled === true,
-            activeGateway: settings.activeGateway || 'stripe'
+            activeGateway: activeGateway
           };
         }
 
         // If no settings row is found, or if the value is null, default to disabled.
         // This is a safe default to prevent users from attempting payments if the system isn't configured.
-        return { enabled: false, activeGateway: 'stripe' };
+        return { enabled: false, activeGateway: 'paystack' };
       } catch (error) {
         console.error('Error in usePaymentGatewaySettings:', error);
         // In case of any unexpected error, default to disabled for safety.
-        return { enabled: false, activeGateway: 'stripe' };
+        return { enabled: false, activeGateway: 'paystack' };
       }
     },
     // Cache the settings for 5 minutes to reduce unnecessary database calls.


### PR DESCRIPTION
This change refactors the usePaymentGatewaySettings hook to improve type safety and robustness, as per user feedback.

- Defines and uses an explicit return type 'PaymentGatewayClientSettings'.
- Adds validation for the 'activeGateway' value to ensure it's a valid gateway.
- Changes the default active gateway to 'paystack'.