### PR TITLE
fix: Add robust JSON parsing for system settings

### DIFF
--- a/src/components/admin/PaymentGatewayManagement.tsx
+++ b/src/components/admin/PaymentGatewayManagement.tsx
@@ -65,7 +65,14 @@ export const PaymentGatewayManagement = () => {
       if (error && error.code !== 'PGRST116') throw error;
 
       if (data?.value) {
-        const dbValue = data.value as Partial<PaymentGatewaySettings>;
+        let dbValue: Partial<PaymentGatewaySettings>;
+        if (typeof data.value === 'string') {
+          console.warn('data.value was stringified JSON, parsing now.');
+          dbValue = JSON.parse(data.value);
+        } else {
+          dbValue = data.value as Partial<PaymentGatewaySettings>;
+        }
+
         const mergedSettings: PaymentGatewaySettings = {
           ...defaultSettings,
           ...dbValue,

--- a/src/hooks/usePaymentGatewaySettings.ts
+++ b/src/hooks/usePaymentGatewaySettings.ts
@@ -36,7 +36,14 @@ export const usePaymentGatewaySettings = () => {
         }
 
         if (gatewayData?.value) {
-          const settings = gatewayData.value as { enabled?: boolean; activeGateway?: string };
+          let settings: { enabled?: boolean; activeGateway?: string };
+          if (typeof gatewayData.value === 'string') {
+            console.warn('gatewayData.value was stringified JSON, parsing now.');
+            settings = JSON.parse(gatewayData.value);
+          } else {
+            settings = gatewayData.value;
+          }
+
           const active = settings.activeGateway;
           const activeGateway: 'stripe' | 'paystack' = active === 'stripe' ? 'stripe' : 'paystack';
 

--- a/supabase/functions/create-payment/index.ts
+++ b/supabase/functions/create-payment/index.ts
@@ -65,7 +65,14 @@ serve(async (req) => {
       throw new Error('Payment settings are not configured in the system.');
     }
 
-    const settings = settingsData.value as PaymentGatewaySettings;
+    let settings: PaymentGatewaySettings;
+    if (typeof settingsData.value === 'string') {
+      console.warn('settingsData.value was stringified JSON, parsing now.');
+      settings = JSON.parse(settingsData.value);
+    } else {
+      settings = settingsData.value as PaymentGatewaySettings;
+    }
+
     const { amount, credits, description, packId } = await req.json();
 
     if (!amount || !credits || amount <= 0 || credits <= 0) {

--- a/supabase/functions/create-subscription/index.ts
+++ b/supabase/functions/create-subscription/index.ts
@@ -63,7 +63,14 @@ serve(async (req) => {
       throw new Error('Payment settings are not configured in the system.');
     }
 
-    const settings = settingsData.value as PaymentGatewaySettings;
+    let settings: PaymentGatewaySettings;
+    if (typeof settingsData.value === 'string') {
+      console.warn('settingsData.value was stringified JSON, parsing now.');
+      settings = JSON.parse(settingsData.value);
+    } else {
+      settings = settingsData.value as PaymentGatewaySettings;
+    }
+
     const { priceId, planId, planName, amount, paystackPlanCode } = await req.json();
 
     if (!planId || !planName || !amount) {


### PR DESCRIPTION
This change fixes a persistent bug where payment settings were not read correctly because the JSONB value was being returned as a string.

Adds a check to parse the value from a string to a JSON object in all places where the setting is read: the admin panel, the client-side hook, and the server-side functions.

This makes the application resilient to how the database driver handles JSONB types.

Also includes a console warning to help with future debugging if this issue occurs.