### PR TITLE
fix: Prevent race condition on payment settings load

### DIFF
--- a/src/pages/Billing.tsx
+++ b/src/pages/Billing.tsx
@@ -93,8 +93,8 @@ const Billing: React.FC = () => {
     try {
       if (paymentSettings?.enabled && paymentSettings?.activeGateway === 'paystack') {
         const paystackPublicKey = paymentSettings.mode === 'live'
-          ? paymentSettings.paystack.live?.publicKey
-          : paymentSettings.paystack.test?.publicKey;
+          ? paymentSettings.paystack?.live?.publicKey
+          : paymentSettings.paystack?.test?.publicKey;
 
         if (!paystackPublicKey) {
           toast.error("Paystack public key is not configured for the current mode.");
@@ -148,7 +148,7 @@ const Billing: React.FC = () => {
     try {
       if (paymentSettings?.enabled && paymentSettings?.activeGateway === 'paystack') {
         const paystackPublicKey = paymentSettings.mode === 'live'
-          ? paymentSettings.paystack.live?.publicKey
+          ? paymentSettings.paystack?.live?.publicKey
           : paymentSettings.paystack?.test?.publicKey;
 
         if (!paystackPublicKey) {
@@ -203,15 +203,15 @@ const Billing: React.FC = () => {
   };
 
   const paystackPublicKey = paymentSettings?.mode === 'live'
-    ? paymentSettings.paystack?.live?.publicKey
-    : paymentSettings.paystack?.test?.publicKey;
+    ? paymentSettings?.paystack?.live?.publicKey
+    : paymentSettings?.paystack?.test?.publicKey;
 
   // A simple check for stripe public key for consistency, assuming it would be structured similarly
   const stripePublicKey = paymentSettings?.mode === 'live'
-    ? paymentSettings.stripe?.live?.publicKey
-    : paymentSettings.stripe?.test?.publicKey;
+    ? paymentSettings?.stripe?.live?.publicKey
+    : paymentSettings?.stripe?.test?.publicKey;
 
-  const paymentReady = paymentSettings?.enabled &&
+  const paymentReady = !isLoadingPaymentSettings && paymentSettings?.enabled &&
     ((paymentSettings.activeGateway === 'paystack' && paystackPublicKey) ||
      (paymentSettings.activeGateway === 'stripe' && stripePublicKey));
 


### PR DESCRIPTION
This change fixes a runtime error on the Billing page caused by a race condition.

The component was attempting to access nested properties of the 'paymentSettings' object before the data was returned from the 'usePaymentGatewaySettings' hook.

The fix adds optional chaining to all nested property access and ensures the 'paymentReady' flag is only true after the settings have finished loading.