### PR TITLE
Fix: Ensure correct Paystack/Stripe public key is used in test mode

### DIFF
--- a/src/hooks/usePaymentPublicKeys.ts
+++ b/src/hooks/usePaymentPublicKeys.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+interface PaymentGatewayKeys {
+  stripe: {
+    live: { publicKey: string };
+    test: { publicKey: string };
+  };
+  paystack: {
+    live: { publicKey: string };
+    test: { publicKey: string };
+  };
+  mode: 'live' | 'test';
+}
+
+interface PublicKeys {
+  stripePublicKey?: string;
+  paystackPublicKey?: string;
+}
+
+export const usePaymentPublicKeys = () => {
+  return useQuery<PublicKeys>({
+    queryKey: ['payment-public-keys'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('system_settings')
+        .select('value')
+        .eq('key', 'payment_gateway_settings')
+        .maybeSingle();
+
+      if (error) {
+        console.error('Error fetching payment public keys:', error);
+        return {};
+      }
+
+      if (data?.value) {
+        const settings = data.value as PaymentGatewayKeys;
+        const mode = settings.mode || 'test';
+
+        return {
+          stripePublicKey: mode === 'live' ? settings.stripe?.live?.publicKey : settings.stripe?.test?.publicKey,
+          paystackPublicKey: mode === 'live' ? settings.paystack?.live?.publicKey : settings.paystack?.test?.publicKey,
+        };
+      }
+
+      return {};
+    },
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+  });
+};

--- a/src/lib/paystack.ts
+++ b/src/lib/paystack.ts
@@ -10,17 +10,19 @@ export const startPaystackPayment = ({
   reference,
   onSuccess,
   onCancel,
+  publicKey,
 }: {
   email: string;
   amount: number; // in Naira
   reference: string;
   onSuccess: (ref: string) => void;
   onCancel: () => void;
+  publicKey: string;
 }) => {
   const paystack = new window.PaystackPop();
 
   paystack.newTransaction({
-    key: import.meta.env.VITE_PAYSTACK_PUBLIC_KEY,
+    key: publicKey,
     email,
     amount: amount * 100, // Paystack wants Kobo
     ref: reference,


### PR DESCRIPTION
This commit resolves an issue where the payment buttons would incorrectly display "Payments Disabled" even when the payment gateway was enabled in "test" mode.

The root cause was that the frontend was not correctly selecting the test public key based on the 'mode' setting in the payment gateway configuration. The code was either looking for a hardcoded live key or not checking for the key's presence at all before disabling the payment button.

The following changes have been made:
1.  A new `usePaymentPublicKeys` hook was created to fetch the payment gateway settings and correctly extract the public key (either 'live' or 'test') based on the current mode.
2.  The `Billing.tsx` component was updated to use this hook and a new `paymentReady` state was introduced. This state ensures that a payment button is only enabled if the payment gateway is active and the corresponding public key is available.
3.  The `startPaystackPayment` function in `lib/paystack.ts` was refactored to accept the public key as a parameter, removing the dependency on a hardcoded environment variable.
4.  The payment buttons in `Billing.tsx` now use the `paymentReady` state to determine if they should be enabled or disabled, and to display the correct text.