### PR TITLE
fix(api): Add missing CORS headers for transaction verification

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -2,4 +2,5 @@
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
 };


### PR DESCRIPTION
The Paystack transaction verification was failing due to a CORS error. This was because the preflight OPTIONS request from the browser was not being handled correctly by the Supabase function.

This commit updates the shared CORS configuration to include the `Access-Control-Allow-Methods` header, which is required to allow cross-origin POST requests. This resolves the CORS error and allows the frontend to verify transactions with the backend.