### PR TITLE
refactor(deps): Standardize Deno std library version across all funct…

### DIFF
--- a/supabase/functions/_shared/paystack.ts
+++ b/supabase/functions/_shared/paystack.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "https://deno.land/std@0.190.0/node/crypto.ts";
+import { createHmac } from "https://deno.land/std@0.208.0/node/crypto.ts";
 
 export interface InitTransactionParams {
   email: string;

--- a/supabase/functions/approve-affiliate-application/index.ts
+++ b/supabase/functions/approve-affiliate-application/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/approve-affiliate-payout-request/index.ts
+++ b/supabase/functions/approve-affiliate-payout-request/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/create-payment/index.ts
+++ b/supabase/functions/create-payment/index.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
 import { PaystackClient } from "../_shared/paystack.ts";

--- a/supabase/functions/create-subscription/index.ts
+++ b/supabase/functions/create-subscription/index.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.21.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
 import { PaystackClient } from "../_shared/paystack.ts";

--- a/supabase/functions/get-affiliate-application-status/index.ts
+++ b/supabase/functions/get-affiliate-application-status/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/get-affiliate-settings/index.ts
+++ b/supabase/functions/get-affiliate-settings/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/get-affiliate-stats/index.ts
+++ b/supabase/functions/get-affiliate-stats/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/get-my-affiliate-stats/index.ts
+++ b/supabase/functions/get-my-affiliate-stats/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/list-affiliate-applications/index.ts
+++ b/supabase/functions/list-affiliate-applications/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/list-affiliate-payout-requests/index.ts
+++ b/supabase/functions/list-affiliate-payout-requests/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/log-affiliate-commission/index.ts
+++ b/supabase/functions/log-affiliate-commission/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts' // Good practice, though less critical for webhooks
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/manage-subscription/index.ts
+++ b/supabase/functions/manage-subscription/index.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import Stripe from "https://esm.sh/stripe@14.21.0"
 

--- a/supabase/functions/paystack-webhook/index.ts
+++ b/supabase/functions/paystack-webhook/index.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { PaystackClient } from '../_shared/paystack.ts'
 

--- a/supabase/functions/process-affiliate-withdrawal/index.ts
+++ b/supabase/functions/process-affiliate-withdrawal/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/reject-affiliate-application/index.ts
+++ b/supabase/functions/reject-affiliate-application/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/reject-affiliate-payout-request/index.ts
+++ b/supabase/functions/reject-affiliate-payout-request/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/request-affiliate-payout/index.ts
+++ b/supabase/functions/request-affiliate-payout/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/request-affiliate-withdrawal/index.ts
+++ b/supabase/functions/request-affiliate-withdrawal/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import Stripe from "https://esm.sh/stripe@14.21.0"
 

--- a/supabase/functions/submit-affiliate-application/index.ts
+++ b/supabase/functions/submit-affiliate-application/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/suno-proxy/index.ts
+++ b/supabase/functions/suno-proxy/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/sync-subscription-role/index.ts
+++ b/supabase/functions/sync-subscription-role/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/testing-reset-affiliate-application/index.ts
+++ b/supabase/functions/testing-reset-affiliate-application/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/track-affiliate-activity/index.ts
+++ b/supabase/functions/track-affiliate-activity/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/track-user-registration/index.ts
+++ b/supabase/functions/track-user-registration/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/update-affiliate-settings/index.ts
+++ b/supabase/functions/update-affiliate-settings/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
 import { corsHeaders } from '../_shared/cors.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 

--- a/supabase/functions/update-api-key/index.ts
+++ b/supabase/functions/update-api-key/index.ts
@@ -1,5 +1,5 @@
 
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts"
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/verify-paystack-transaction/index.ts
+++ b/supabase/functions/verify-paystack-transaction/index.ts
@@ -1,4 +1,4 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0';
 import { corsHeaders } from '../_shared/cors.ts';
 


### PR DESCRIPTION
…ions

This commit updates all Supabase Edge Functions to use a consistent version of the Deno standard library (`deno.land/std@0.208.0`).

Previously, multiple different versions of `std` were being used across the functions, including the very old version `0.168.0`. This inconsistency was causing a critical bug where `OPTIONS` preflight requests were failing with a `404 Not Found` error, breaking CORS and preventing frontend applications from calling the functions.

By standardizing on a single, modern version of the `std` library, we ensure:
- Compatibility with the current Supabase Edge Function runtime.
- Consistent behavior across all functions.
- Resolution of the CORS preflight bug.
- Improved maintainability of the codebase.

This change touches many function files but is essential for the stability and correctness of the backend services.