### PR TITLE
feat: Add `test-cors` function for debugging

### DIFF
--- a/supabase/functions/test-cors/index.ts
+++ b/supabase/functions/test-cors/index.ts
@@ -1,0 +1,19 @@
+import { serve } from 'https://deno.land/std@0.208.0/http/server.ts'
+import { corsHeaders } from '../_shared/cors.ts'
+
+console.log("`test-cors` function script started.");
+
+serve(async (req) => {
+  console.log("`test-cors` function invoked with method:", req.method);
+
+  if (req.method === 'OPTIONS') {
+    console.log("Responding to OPTIONS request in `test-cors`");
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  console.log("Responding to non-OPTIONS request in `test-cors`");
+  return new Response(JSON.stringify({ message: 'Hello from test-cors!' }), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    status: 200,
+  })
+})


### PR DESCRIPTION
Add a minimal Supabase Edge Function named `test-cors` to diagnose the persistent `404 Not Found` error on `OPTIONS` requests.

This function contains basic, explicit CORS handling and logging. It will be used to determine if the issue is specific to the `verify-paystack` function or if it's a project-wide issue with the Supabase platform's routing of preflight requests.