### PR TITLE
fix: handle stringified metadata in paystack verification

### DIFF
--- a/supabase/functions/verify-paystack-transaction/index.ts
+++ b/supabase/functions/verify-paystack-transaction/index.ts
@@ -61,8 +61,19 @@ serve(async (req) => {
       });
     }
 
-    const userId = verificationData.data.metadata?.user_id;
+    let metadata = verificationData.data.metadata;
+    if (typeof metadata === 'string') {
+      try {
+        metadata = JSON.parse(metadata);
+      } catch (e) {
+        console.error('Failed to parse transaction metadata:', metadata);
+        throw new Error('Failed to parse transaction metadata.');
+      }
+    }
+
+    const userId = metadata?.user_id;
     if (!userId) {
+      console.error('User ID not found in transaction metadata:', metadata);
       throw new Error('User ID not found in transaction metadata.');
     }
 


### PR DESCRIPTION
The `verify-paystack-transaction` function was failing with a 500 error because the `metadata` field from the Paystack API was sometimes a stringified JSON object instead of a parsed object. This caused an error when trying to access `metadata.user_id`.

This commit adds a check to see if `metadata` is a string, and if so, parses it into an object before further processing. It also adds more detailed logging to help debug any future issues.