### PR TITLE
This commit introduces a new feature that allows administrators to se…

### DIFF
--- a/src/components/admin/PaymentGatewayManagement.tsx
+++ b/src/components/admin/PaymentGatewayManagement.tsx
@@ -18,6 +18,7 @@ interface ApiKeys {
 interface GatewayConfig {
   test: ApiKeys;
   live: ApiKeys;
+  usdToNgnRate?: number;
 }
 
 interface PaymentGatewaySettings {
@@ -39,6 +40,7 @@ const defaultSettings: PaymentGatewaySettings = {
   paystack: {
     test: { publicKey: '', secretKey: '' },
     live: { publicKey: '', secretKey: '' },
+    usdToNgnRate: 1500,
   },
 };
 
@@ -180,6 +182,18 @@ export const PaymentGatewayManagement = () => {
     setIsDirty(true);
   };
 
+  const handlePaystackRateChange = (value: string) => {
+    const rate = parseFloat(value) || 0;
+    setSettings(prev => ({
+        ...prev,
+        paystack: {
+            ...prev.paystack,
+            usdToNgnRate: rate,
+        },
+    }));
+    setIsDirty(true);
+  };
+
   if (loading) {
     return <Card><CardHeader><CardTitle>Payment Gateway Settings</CardTitle><CardDescription>Loading...</CardDescription></CardHeader><CardContent className="flex items-center justify-center p-8"><Loader2 className="h-8 w-8 animate-spin" /></CardContent></Card>;
   }
@@ -251,7 +265,21 @@ export const PaymentGatewayManagement = () => {
                 </div>
               </TabsContent>
               <TabsContent value="paystack" className="p-4 border rounded-lg mt-2">
-                <h3 className="text-lg font-medium mb-4">Paystack API Keys</h3>
+                <h3 className="text-lg font-medium mb-4">Paystack Settings</h3>
+                <div className="space-y-4 mb-6 border-b pb-6">
+                  <Label htmlFor="paystack-rate">USD to NGN Exchange Rate</Label>
+                  <Input
+                    id="paystack-rate"
+                    type="number"
+                    placeholder="e.g., 1500"
+                    value={settings.paystack.usdToNgnRate || ''}
+                    onChange={(e) => handlePaystackRateChange(e.target.value)}
+                  />
+                  <p className="text-sm text-muted-foreground">
+                    Set the value of 1 USD in NGN for Paystack transactions.
+                  </p>
+                </div>
+                <h4 className="text-base font-medium mb-4">Paystack API Keys</h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div className="space-y-4">
                     <h4 className="font-medium text-muted-foreground">Test Keys</h4>

--- a/src/lib/paystack.ts
+++ b/src/lib/paystack.ts
@@ -2,7 +2,8 @@ import Paystack from '@paystack/inline-js';
 
 export const startPaystackPayment = ({
   email,
-  amount,
+  usdAmount,
+  usdToNgnRate,
   reference,
   onSuccess,
   onCancel,
@@ -10,7 +11,8 @@ export const startPaystackPayment = ({
   metadata,
 }: {
   email: string;
-  amount: number; // in USD
+  usdAmount: number;
+  usdToNgnRate: number;
   reference: string;
   onSuccess: (ref: string) => void;
   onCancel: () => void;
@@ -18,12 +20,13 @@ export const startPaystackPayment = ({
   metadata?: Record<string, unknown>;
 }) => {
   const paystack = new Paystack();
+  const ngnAmountInKobo = Math.round(usdAmount * usdToNgnRate * 100);
 
   paystack.checkout({
     key: publicKey,
     email,
-    amount: amount * 100, // Paystack wants cents
-    currency: 'USD',
+    amount: ngnAmountInKobo,
+    currency: 'NGN',
     ref: reference,
     metadata,
     onSuccess: (transaction: { reference: string }) => {

--- a/src/pages/Billing.tsx
+++ b/src/pages/Billing.tsx
@@ -144,8 +144,8 @@ const Billing: React.FC = () => {
     setPaymentProcessing(true);
     try {
       if (paymentSettings?.enabled && paymentSettings?.activeGateway === 'paystack') {
-        if (!publicKeys?.paystackPublicKey) {
-          toast.error("Paystack public key not found. Cannot proceed with payment.");
+        if (!publicKeys?.paystackPublicKey || !paymentSettings.paystack.usdToNgnRate) {
+          toast.error("Paystack is not configured correctly. Missing public key or exchange rate.");
           setPaymentProcessing(false);
           return;
         }
@@ -153,7 +153,8 @@ const Billing: React.FC = () => {
         await startPaystackPayment({
           publicKey: publicKeys.paystackPublicKey,
           email: user.email!,
-          amount: plan.price,
+          usdAmount: plan.price,
+          usdToNgnRate: paymentSettings.paystack.usdToNgnRate,
           reference: reference,
           metadata: {
             user_id: user.id,
@@ -244,8 +245,8 @@ const Billing: React.FC = () => {
     setProcessing(true);
     try {
       if (paymentSettings?.enabled && paymentSettings?.activeGateway === 'paystack') {
-        if (!publicKeys?.paystackPublicKey) {
-          toast.error("Paystack public key not found. Cannot proceed with payment.");
+        if (!publicKeys?.paystackPublicKey || !paymentSettings.paystack.usdToNgnRate) {
+          toast.error("Paystack is not configured correctly. Missing public key or exchange rate.");
           setProcessing(false);
           return;
         }
@@ -253,7 +254,8 @@ const Billing: React.FC = () => {
         await startPaystackPayment({
           publicKey: publicKeys.paystackPublicKey,
           email: user.email!,
-          amount: selectedPackage.amount,
+          usdAmount: selectedPackage.amount,
+          usdToNgnRate: paymentSettings.paystack.usdToNgnRate,
           reference: reference,
           metadata: {
             user_id: user.id,

--- a/supabase/functions/_shared/paystack.ts
+++ b/supabase/functions/_shared/paystack.ts
@@ -5,7 +5,7 @@ export interface InitTransactionParams {
   amount?: number; // in kobo (e.g., ₦1000 => 100000)
   currency?: string;
   callback_url?: string;
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, any>;
   plan?: string;
 }
 
@@ -21,7 +21,7 @@ export interface VerifyResponse {
   amount: number;
   currency: string;
   customer: { email: string };
-  [key: string]: unknown;
+  [key: string]: any;
 }
 
 export class PaystackClient {
@@ -62,9 +62,9 @@ export class PaystackClient {
   }
 
   async initTransaction(params: InitTransactionParams): Promise<InitTransactionResponse> {
-    const body: Record<string, unknown> = {
+    const body: any = {
       email: params.email,
-      currency: params.currency ?? "USD",
+      currency: params.currency ?? "NGN",
       callback_url: params.callback_url,
       metadata: params.metadata,
     };

--- a/supabase/functions/create-payment/index.ts
+++ b/supabase/functions/create-payment/index.ts
@@ -11,6 +11,7 @@ interface ApiKeys {
 interface GatewayConfig {
   test: ApiKeys;
   live: ApiKeys;
+  usdToNgnRate?: number;
 }
 interface PaymentGatewaySettings {
   enabled: boolean;
@@ -126,17 +127,23 @@ serve(async (req) => {
     // --- Paystack Payment Flow ---
     if (settings.activeGateway === 'paystack') {
       const paystackKeys = settings.mode === 'live' ? settings.paystack.live : settings.paystack.test;
-      if (!paystackKeys?.secretKey) {
-        throw new Error(`Paystack secret key for ${settings.mode} mode is not configured.`);
+      const usdToNgnRate = settings.paystack.usdToNgnRate;
+
+      if (!paystackKeys?.secretKey || !usdToNgnRate) {
+        throw new Error(`Paystack secret key or exchange rate for ${settings.mode} mode is not configured.`);
       }
+
+      // The incoming amount is in USD cents. Convert to NGN Kobo.
+      // e.g. $10 (1000 cents) * 1500 rate = 1,500,000 kobo (which is 15,000 NGN)
+      const ngnAmountInKobo = Math.round(amount * usdToNgnRate);
 
       const paystack = new PaystackClient(paystackKeys.secretKey);
       const tx = await paystack.initTransaction({
         email: user.email,
-        amount: amount,
-        currency: 'USD',
+        amount: ngnAmountInKobo,
+        currency: 'NGN',
         callback_url: `${req.headers.get("origin")}/billing?payment=success`,
-        metadata: { type: 'credits', user_id: user.id, credits: credits, pack_id: packId, user_email: user.email }
+        metadata: { type: 'credits', user_id: user.id, credits: credits, pack_id: packId, user_email: user.email, original_usd_amount: amount / 100 }
       });
 
       if (!tx.authorization_url) throw new Error("Paystack transaction created but no authorization URL returned");


### PR DESCRIPTION
…t a USD-to-NGN exchange rate for Paystack payments.

When a user makes a payment via Paystack, the system now converts the USD price of the product or plan into NGN using the admin-defined rate. The final charge is then processed by Paystack in NGN.

Changes include:
- A new input field in the Admin Panel under Payment Gateway settings to configure the USD-NGN exchange rate.
- Updated frontend payment logic in the Billing page to fetch the rate and perform the conversion before calling the Paystack inline checkout.
- Updated the server-side `create-payment` function to also perform this conversion, ensuring consistency for any backend-initiated payments.