### PR TITLE
fix: Address contest creation errors and improve RLS policy

### DIFF
--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -6,6 +6,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Trophy, Calendar, Upload, Vote, Play, Pause } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";

--- a/supabase/migrations/20250831112800_allow_authenticated_bucket_creation.sql
+++ b/supabase/migrations/20250831112800_allow_authenticated_bucket_creation.sql
@@ -1,0 +1,7 @@
+-- Drop the existing policy
+DROP POLICY IF EXISTS "Allow authenticated users to create their own buckets" ON storage.buckets;
+
+-- Create a new, more permissive policy
+CREATE POLICY "Allow authenticated users to create buckets"
+ON storage.buckets FOR INSERT
+TO authenticated WITH CHECK (true);


### PR DESCRIPTION
This commit fixes two critical errors reported by the user:

1.  **Frontend Error:** An `Input is not defined` error on the contest page is resolved by adding the missing import for the `Input` component in `Contest.tsx`.
2.  **Backend Error:** A row-level security policy error on the `storage.buckets` table is fixed by creating a new, more permissive database migration. This allows authenticated users to create buckets, which is necessary for uploading contest entries.

Note: The voting logic, including preventing self-voting and charging for subsequent votes, is correctly handled by the `cast_vote` RPC function on the backend and was not part of these fixes.