### PR TITLE
fix: Resolve race condition in contest page

### DIFF
--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -55,13 +55,13 @@ interface Song {
 }
 
 const Contest = () => {
-  const { user, isVoter, isSubscriber, userRoles } = useAuth();
+  const { user, isVoter, isSubscriber, userRoles, loading: authLoading } = useAuth();
   const {
     upcomingContests,
     activeContests,
     pastContests,
     contestEntries,
-    loading,
+    loading: contestLoading,
     isVoting,
     castVote,
     checkHasFreeVote,
@@ -202,11 +202,11 @@ const Contest = () => {
     return <span className="text-sm font-mono">{timeLeft}</span>;
   };
 
-  if (loading) {
+  if (authLoading || contestLoading) {
     return (
       <div className="flex justify-center items-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
-        <span className="ml-2">Loading contests...</span>
+        <span className="ml-2">Loading...</span>
       </div>
     );
   }
@@ -218,6 +218,11 @@ const Contest = () => {
         <p className="text-gray-400">
           Showcase your talent and win amazing prizes!
         </p>
+        {user && (
+          <p className="text-sm text-gray-300 mt-2">
+            Your Credits: <span className="font-bold text-dark-purple">{user.profile?.credits ?? 'Loading...'}</span>
+          </p>
+        )}
       </div>
 
       <Tabs defaultValue="active" className="w-full flex flex-col flex-grow mt-6">


### PR DESCRIPTION
This commit fixes a bug where the 'Unlock Contest' button was disabled incorrectly. This was caused by a race condition where the contest page would render before the user's profile and credit balance had finished loading from the AuthContext.

The fix introduces a check for the `loading` state from `useAuth` in the `Contest.tsx` component. The page now displays a loading indicator until both the authentication data and the contest data are fully loaded, ensuring the user's credit balance is available when the unlock button is rendered.