### PR TITLE
fix: Correctly access user credits on contest page

### DIFF
--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -220,7 +220,7 @@ const Contest = () => {
         </p>
         {user && (
           <p className="text-sm text-gray-300 mt-2">
-            Your Credits: <span className="font-bold text-dark-purple">{user.profile?.credits ?? 'Loading...'}</span>
+            Your Credits: <span className="font-bold text-dark-purple">{user?.credits ?? 'Loading...'}</span>
           </p>
         )}
       </div>
@@ -261,7 +261,7 @@ const Contest = () => {
                           Submit Entry
                         </Button>
                       ) : (
-                        <Button size="sm" onClick={() => handleUnlockContest(contest)} disabled={submitting || (user?.profile?.credits ?? 0) < contest.entry_fee}>
+                        <Button size="sm" onClick={() => handleUnlockContest(contest)} disabled={submitting || (user?.credits ?? 0) < contest.entry_fee}>
                           {submitting ? 'Unlocking...' : `Unlock for ${contest.entry_fee} credits`}
                         </Button>
                       )}


### PR DESCRIPTION
This commit provides the definitive fix for the non-functional 'Unlock Contest' button. The root cause was an incorrect data access pattern where the code was attempting to read `user.profile.credits` instead of the correct `user.credits`.

This has been corrected in two places in `Contest.tsx`:
1. The text element that displays the user's credit balance.
2. The `disabled` logic on the unlock button itself.

This ensures the button is correctly enabled or disabled based on the user's actual credit balance.