### PR TITLE
debug: Add diagnostic logging for contest unlock feature

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -383,15 +383,26 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     if (!user) return;
 
     try {
+      console.log(`[DEBUG] updateUserCredits called with amount: ${amount}`);
       const { data, error } = await supabase.rpc('update_user_credits', {
         p_user_id: user.id,
         p_amount: amount
       });
+      console.log(`[DEBUG] RPC returned. Error: ${JSON.stringify(error)}, Data: ${JSON.stringify(data)}`);
 
-      if (error) throw error;
+      if (error) {
+        console.error('[DEBUG] Throwing error from updateUserCredits');
+        throw error;
+      }
 
       const newBalance = typeof data === 'number' ? data : parseInt(data, 10) || 0;
-      setUser(prev => prev ? { ...prev, credits: newBalance } : null);
+      console.log(`[DEBUG] Calculated newBalance: ${newBalance}`);
+
+      setUser(prev => {
+        const newState = prev ? { ...prev, credits: newBalance } : null;
+        console.log('[DEBUG] Calling setUser. Previous state:', prev, 'New state:', newState);
+        return newState;
+      });
     } catch (error) {
       console.error('Error updating credits:', error);
       throw error;

--- a/src/hooks/use-contest.ts
+++ b/src/hooks/use-contest.ts
@@ -381,7 +381,9 @@ export const useContest = () => {
       }
 
       // Deduct credits
+      console.log(`[DEBUG] Calling updateUserCredits with fee: ${-fee}`);
       await updateUserCredits(-fee);
+      console.log('[DEBUG] Finished awaiting updateUserCredits.');
 
       // Record the unlock
       const { error: unlockError } = await supabase


### PR DESCRIPTION
This commit adds detailed `console.log` statements to the `unlockContest` and `updateUserCredits` functions. This is intended to help diagnose a persistent bug where the UI state is not updating correctly after a user unlocks a contest.

This is a temporary debugging measure. The logs will be removed once the root cause is identified and fixed.