### PR TITLE
fix(contest): hide ended contest tabs on entries page

### DIFF
--- a/src/hooks/use-contest.ts
+++ b/src/hooks/use-contest.ts
@@ -109,16 +109,27 @@ export const useContest = () => {
       setUnlockedContestIds(newUnlockedIds);
       
       const allContests = data || [];
+      const now = new Date();
 
-      const active = allContests
-        .filter(contest => contest.status === 'active')
-        .map(contest => ({
-          ...contest,
-          is_unlocked: newUnlockedIds.has(contest.id)
-        }));
-      
-      const upcoming = allContests.filter(contest => contest.status === 'upcoming');
-      const past = allContests.filter(contest => contest.status === 'past');
+      const active: Contest[] = [];
+      const upcoming: Contest[] = [];
+      const past: Contest[] = [];
+
+      allContests.forEach(contest => {
+        const startDate = new Date(contest.start_date);
+        const endDate = new Date(contest.end_date);
+
+        if (endDate < now) {
+          past.push(contest);
+        } else if (startDate > now) {
+          upcoming.push(contest);
+        } else {
+          active.push({
+            ...contest,
+            is_unlocked: newUnlockedIds.has(contest.id)
+          });
+        }
+      });
 
       setActiveContests(active);
       setUpcomingContests(upcoming);


### PR DESCRIPTION
Dynamically determine contest status based on start and end dates, removing reliance on the database 'status' field. This ensures that once a contest's end date has passed, it is correctly categorized as 'past' and no longer appears in the 'active' or 'entries' tabs.