### PR TITLE
Fix: Resolve TypeError during contest voting

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -32,6 +32,7 @@ interface AuthContextType {
   hasRole: (role: string) => boolean;
   hasAdminPermission: (permission: string) => boolean;
   updateUserCredits: (amount: number) => Promise<void>;
+  refreshProfile: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -426,6 +427,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return isAdmin() || isSuperAdmin();
   };
 
+  const refreshProfile = async () => {
+    if (!user) return;
+    try {
+      const userData = await fetchUserData(user.id);
+      if (userData) {
+        setUser(userData);
+      }
+    } catch (error) {
+      console.error("Error refreshing user profile:", error);
+    }
+  };
+
   const value = {
     user,
     session,
@@ -441,6 +454,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     hasRole,
     hasAdminPermission,
     updateUserCredits,
+    refreshProfile,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/hooks/use-contest.ts
+++ b/src/hooks/use-contest.ts
@@ -42,7 +42,7 @@ export interface ContestEntry {
 }
 
 export const useContest = () => {
-  const { user, updateUserCredits, isSubscriber } = useAuth();
+  const { user, updateUserCredits, isSubscriber, refreshProfile } = useAuth();
   const [contests, setContests] = useState<Contest[]>([]);
   const [activeContests, setActiveContests] = useState<Contest[]>([]);
   const [upcomingContests, setUpcomingContests] = useState<Contest[]>([]);
@@ -536,7 +536,7 @@ export const useContest = () => {
       if (data.success) {
         toast.success(data.message);
         // Refresh user credits from auth context
-        await user.refreshProfile();
+        await refreshProfile();
         // Refresh contest entries to show new vote count
         if (currentContest) {
           fetchContestEntries(currentContest.id);


### PR DESCRIPTION
This commit addresses a `TypeError: e.refreshProfile is not a function` that occurred after a user cast a vote in a contest.

The error was caused by an incorrect attempt to call `refreshProfile` on the `user` object returned by the `useAuth` hook. The `user` object did not have this method.

The following changes have been made to resolve this issue:

- A `refreshProfile` function has been added to `AuthContext.tsx`. This function fetches the latest user data and updates the `user` state in the `AuthContext`.
- The `refreshProfile` function is now exposed through the `useAuth` hook.
- The `castVote` function in `src/hooks/use-contest.ts` has been updated to use the new `refreshProfile` function from the `useAuth` hook.