### PR TITLE
feat(billing): Update button text to be generic

### DIFF
--- a/src/pages/Billing.tsx
+++ b/src/pages/Billing.tsx
@@ -341,8 +341,7 @@ const Billing: React.FC = () => {
     if (!currentUserPlan) return 'Subscribe Now';
     if (plan.id === currentUserPlan.id) return 'Current Plan';
     if (plan.rank > currentUserPlan.rank) {
-      const gateway = paymentSettings?.activeGateway === 'paystack' ? 'Paystack' : 'Stripe';
-      return `Upgrade with ${gateway}`;
+      return 'Upgrade';
     }
     return 'Downgrade';
   };
@@ -430,7 +429,7 @@ const Billing: React.FC = () => {
                       ? 'Loading...'
                       : !paymentReady
                       ? 'Payments Disabled'
-                      : `Purchase with ${paymentSettings.activeGateway === 'paystack' ? 'Paystack' : 'Stripe'}`}
+                      : 'Purchase'}
                   </Button>
                 </CardContent>
               </Card>
@@ -456,7 +455,7 @@ const Billing: React.FC = () => {
                     ? 'Loading...'
                     : !paymentReady
                     ? 'Payments Disabled'
-                    : `Purchase with ${paymentSettings.activeGateway === 'paystack' ? 'Paystack' : 'Stripe'}`}
+                    : 'Purchase'}
                 </Button>
               </div>
             </CardContent>


### PR DESCRIPTION
This commit updates the button text on the billing page to be more generic, as requested.

- Changes "Upgrade with [Gateway]" to "Upgrade".
- Changes "Purchase with [Gateway]" to "Purchase".

This provides a cleaner user interface and removes the explicit mention of the payment gateway from the button text.