### PR TITLE
feat: Implement automatic contest winner selection and display

### DIFF
--- a/src/components/contest/ContestWinnerBanner.tsx
+++ b/src/components/contest/ContestWinnerBanner.tsx
@@ -1,0 +1,103 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '@/components/ui/carousel';
+import { Trophy } from 'lucide-react';
+
+interface ContestWinner {
+  contest_title: string;
+  winner_name: string;
+  entry_description: string;
+}
+
+const ContestWinnerBanner = () => {
+  const [winners, setWinners] = useState<ContestWinner[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchWinners = async () => {
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+      const { data, error } = await supabase
+        .from('contest_winners')
+        .select(`
+          won_at,
+          contests!inner(title),
+          profiles!inner(full_name),
+          contest_entries!inner(description)
+        `)
+        .gte('won_at', thirtyDaysAgo.toISOString())
+        .order('won_at', { ascending: false });
+
+      if (error) {
+        console.error('Error fetching contest winners:', error);
+        setLoading(false);
+        return;
+      }
+
+      const formattedWinners = data.map(item => ({
+        contest_title: item.contests.title,
+        winner_name: item.profiles.full_name,
+        entry_description: item.contest_entries.description,
+      }));
+
+      setWinners(formattedWinners);
+      setLoading(false);
+    };
+
+    fetchWinners();
+  }, []);
+
+  if (loading) {
+    return null;
+  }
+
+  if (winners.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-gray-900 text-white py-8">
+      <div className="container mx-auto">
+        <h2 className="text-2xl font-bold text-center mb-4">
+          <Trophy className="inline-block mr-2 text-yellow-400" />
+          Recent Contest Winners
+        </h2>
+        <Carousel
+          opts={{
+            align: 'start',
+            loop: true,
+          }}
+          className="w-full max-w-4xl mx-auto"
+        >
+          <CarouselContent>
+            {winners.map((winner, index) => (
+              <CarouselItem key={index}>
+                <div className="p-1">
+                  <Card className="bg-gray-800 border-gray-700">
+                    <CardContent className="flex flex-col items-center justify-center p-6">
+                      <h3 className="text-xl font-semibold text-yellow-400">{winner.contest_title}</h3>
+                      <p className="text-lg mt-2">Winner: {winner.winner_name}</p>
+                      <p className="text-md text-gray-400 mt-1">Entry: "{winner.entry_description}"</p>
+                    </CardContent>
+                  </Card>
+                </div>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          <CarouselPrevious />
+          <CarouselNext />
+        </Carousel>
+      </div>
+    </div>
+  );
+};
+
+export default ContestWinnerBanner;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Music, Coins } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
+import ContestWinnerBanner from "@/components/contest/ContestWinnerBanner";
 
 // Helper component for the floating icons
 const FloatingIcon = ({
@@ -111,6 +112,7 @@ export default function Index() {
                 </button>
               </div>
             </section>
+            <ContestWinnerBanner />
         </div>
       </main>
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -69,3 +69,7 @@ verify_jwt = false
 
 [functions.payment-webhook]
 verify_jwt = false
+
+[functions.select-contest-winner]
+cron = "0 * * * *"
+verify_jwt = false

--- a/supabase/functions/select-contest-winner/index.ts
+++ b/supabase/functions/select-contest-winner/index.ts
@@ -1,0 +1,95 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+const supabaseAdmin = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+);
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { data: contests, error: contestError } = await supabaseAdmin
+      .from('contests')
+      .select('id, title')
+      .lt('end_date', new Date().toISOString())
+      .eq('status', 'active');
+
+    if (contestError) {
+      throw contestError;
+    }
+
+    if (!contests || contests.length === 0) {
+      return new Response(JSON.stringify({ message: 'No contests ended.' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 200,
+      });
+    }
+
+    for (const contest of contests) {
+      const { data: topEntries, error: entriesError } = await supabaseAdmin
+        .from('contest_entries')
+        .select('id, user_id, vote_count')
+        .eq('contest_id', contest.id)
+        .order('vote_count', { ascending: false })
+        .limit(1);
+
+      if (entriesError) {
+        console.error(`Error fetching entries for contest ${contest.id}:`, entriesError);
+        continue;
+      }
+
+      if (!topEntries || topEntries.length === 0) {
+        // No entries, just mark the contest as completed
+        await supabaseAdmin
+          .from('contests')
+          .update({ status: 'completed' })
+          .eq('id', contest.id);
+        continue;
+      }
+
+      const maxVotes = topEntries[0].vote_count;
+
+      const { data: winners, error: winnersError } = await supabaseAdmin
+        .from('contest_entries')
+        .select('id, user_id')
+        .eq('contest_id', contest.id)
+        .eq('vote_count', maxVotes);
+
+      if (winnersError) {
+        console.error(`Error fetching winners for contest ${contest.id}:`, winnersError);
+        continue;
+      }
+
+      if (winners && winners.length > 0) {
+        const winnerInserts = winners.map(winner => ({
+          contest_id: contest.id,
+          user_id: winner.user_id,
+          contest_entry_id: winner.id,
+          rank: 1,
+        }));
+
+        await supabaseAdmin.from('contest_winners').insert(winnerInserts);
+      }
+
+      await supabaseAdmin
+        .from('contests')
+        .update({ status: 'completed' })
+        .eq('id', contest.id);
+    }
+
+    return new Response(JSON.stringify({ message: 'Contest winners selected successfully.' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 200,
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 500,
+    });
+  }
+});

--- a/supabase/migrations/20250901120000_create_contest_winners_table.sql
+++ b/supabase/migrations/20250901120000_create_contest_winners_table.sql
@@ -1,0 +1,28 @@
+-- Create the contest_winners table
+CREATE TABLE public.contest_winners (
+    id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    contest_id UUID NOT NULL REFERENCES public.contests(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    contest_entry_id UUID NOT NULL REFERENCES public.contest_entries(id) ON DELETE CASCADE,
+    rank INTEGER NOT NULL DEFAULT 1,
+    won_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Add indexes for faster queries
+CREATE INDEX idx_contest_winners_contest_id ON public.contest_winners(contest_id);
+CREATE INDEX idx_contest_winners_user_id ON public.contest_winners(user_id);
+
+-- Enable Row Level Security
+ALTER TABLE public.contest_winners ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies for contest_winners
+CREATE POLICY "Public can view all contest winners"
+ON public.contest_winners
+FOR SELECT
+USING (true);
+
+CREATE POLICY "Admins can manage contest winners"
+ON public.contest_winners
+FOR ALL
+USING (is_admin(auth.uid()))
+WITH CHECK (is_admin(auth.uid()));


### PR DESCRIPTION
This commit introduces a new feature to automatically select and display contest winners.

The changes include:
- A new database table `contest_winners` to store winner information.
- A Supabase Edge Function `select-contest-winner` that runs on a cron schedule to automatically select winners based on vote count for ended contests.
- A new React component `ContestWinnerBanner.tsx` to display recent winners on the homepage.
- The `ContestWinnerBanner` is integrated into the homepage and will display winners from the last 30 days in a carousel.