### PR TITLE
feat: Add homepage hero banner with video and CTA

### DIFF
--- a/src/components/admin/SiteSettingsManagement.tsx
+++ b/src/components/admin/SiteSettingsManagement.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { Loader2, Upload } from 'lucide-react';
+
+export const SiteSettingsManagement = () => {
+  const [videoUrl, setVideoUrl] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [videoFile, setVideoFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from('site_settings')
+        .select('value')
+        .eq('key', 'homepage_hero_video_url')
+        .single();
+
+      if (error) {
+        toast.error('Failed to fetch site settings.');
+        console.error(error);
+      } else {
+        setVideoUrl(data.value || '');
+      }
+      setLoading(false);
+    };
+
+    fetchSettings();
+  }, []);
+
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      if (!file.type.startsWith('video/')) {
+        toast.error('Please select a video file.');
+        return;
+      }
+      if (file.size > 100 * 1024 * 1024) { // 100MB limit
+        toast.error('File size must be less than 100MB.');
+        return;
+      }
+      setVideoFile(file);
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!videoFile) {
+      toast.error('Please select a video file to upload.');
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const timestamp = Date.now();
+      const filename = `${timestamp}_${videoFile.name.replace(/[^a-zA-Z0-9.-]/g, '_')}`;
+
+      const { data: uploadData, error: uploadError } = await supabase.storage
+        .from('public-assets')
+        .upload(filename, videoFile, {
+          contentType: videoFile.type,
+          upsert: false,
+        });
+
+      if (uploadError) {
+        throw uploadError;
+      }
+
+      const { data: { publicUrl } } = supabase.storage
+        .from('public-assets')
+        .getPublicUrl(filename);
+
+      if (!publicUrl) {
+        throw new Error('Failed to get public URL for the uploaded video.');
+      }
+
+      const { error: updateError } = await supabase
+        .from('site_settings')
+        .update({ value: publicUrl })
+        .eq('key', 'homepage_hero_video_url');
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      setVideoUrl(publicUrl);
+      setVideoFile(null);
+      toast.success('Hero video updated successfully.');
+    } catch (error: any) {
+      toast.error(error.message || 'Failed to upload video.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Site Settings</CardTitle>
+        <CardDescription>Manage site-wide settings.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label>Homepage Hero Video</Label>
+          {videoUrl ? (
+            <div className="space-y-2">
+              <video src={videoUrl} controls className="w-full rounded-md" />
+              <p className="text-sm text-muted-foreground">Current video URL: {videoUrl}</p>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No video uploaded yet.</p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label>Upload New Video</Label>
+          <div className="flex items-center space-x-2">
+            <Input type="file" accept="video/*" onChange={handleFileSelect} />
+            <Button onClick={handleUpload} disabled={uploading || !videoFile}>
+              {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+              <span className="ml-2">Upload</span>
+            </Button>
+          </div>
+          {videoFile && <p className="text-sm text-muted-foreground">Selected file: {videoFile.name}</p>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -18,6 +18,7 @@ import { PaymentManagement } from "@/components/admin/PaymentManagement";
 import { SupportManagement } from "@/components/admin/SupportManagement";
 import { ReportsAnalytics } from "@/components/admin/ReportsAnalytics";
 import { SettingsManagement } from "@/components/admin/SettingsManagement";
+import { SiteSettingsManagement } from "@/components/admin/SiteSettingsManagement";
 import AffiliateManagementTab from "@/components/admin/affiliate/AffiliateManagementTab";
 
 interface AdminProps {
@@ -372,8 +373,9 @@ const Admin = ({ tab }: AdminProps) => {
                 <CardTitle>System Settings</CardTitle>
                 <CardDescription>Configure system-wide settings and preferences</CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="space-y-4">
                 <SettingsManagement />
+                <SiteSettingsManagement />
               </CardContent>
             </Card>
           </TabsContent>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,8 @@ import { Music, Coins } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import ContestWinnerBanner from "@/components/contest/ContestWinnerBanner";
+import { supabase } from "@/integrations/supabase/client";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
 
 // Helper component for the floating icons
 const FloatingIcon = ({
@@ -28,6 +30,25 @@ export default function Index() {
   const navigate = useNavigate();
   const { user, loading, isAdmin, isSuperAdmin } = useAuth();
   const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [heroVideoUrl, setHeroVideoUrl] = useState('');
+
+  useEffect(() => {
+    const fetchHeroVideoUrl = async () => {
+      const { data, error } = await supabase
+        .from('site_settings')
+        .select('value')
+        .eq('key', 'homepage_hero_video_url')
+        .single();
+
+      if (error) {
+        console.error('Error fetching hero video URL:', error);
+      } else if (data) {
+        setHeroVideoUrl(data.value);
+      }
+    };
+
+    fetchHeroVideoUrl();
+  }, []);
 
   // Redirect authenticated users to appropriate dashboard
   useEffect(() => {
@@ -88,27 +109,25 @@ export default function Index() {
 
       <main className="relative z-10 grid place-items-center min-h-screen w-full text-center p-4">
         <div>
-            {/* Hero Section */}
+            {/* New Hero Section */}
             <section className="w-full max-w-4xl">
-              <div className="relative inline-block">
-                <div className="absolute -inset-2 bg-black/30 rounded-full blur-lg"></div>
-                <h1 className="relative text-6xl font-bold text-dark-purple">
-                  Afroverse
-                </h1>
-              </div>
-              <p className="mt-4 text-2xl font-semibold text-gray-100">
-                Create Afrobeats with AI. Earn while you play.
-              </p>
-              <p className="mt-6 max-w-2xl mx-auto text-gray-400 font-light">
-                Afroverse lets you turn text into full Afrobeats songs in seconds — and compete in monthly contests where your creativity can win record deals, cash, and promo.
-              </p>
-
+              {heroVideoUrl && (
+                <AspectRatio ratio={16 / 9} className="bg-muted">
+                  <video
+                    src={heroVideoUrl}
+                    autoPlay
+                    muted
+                    loop
+                    className="w-full h-full object-cover rounded-lg"
+                  />
+                </AspectRatio>
+              )}
               <div className="mt-10 flex justify-center">
                 <button
-                  onClick={() => setShowConfirmModal(true)}
+                  onClick={() => navigate('/contest')}
                   className="px-8 py-4 bg-dark-purple rounded-lg font-bold text-white hover:bg-opacity-90 transition-all duration-300"
                 >
-                  Claim Early Access
+                  Earn
                 </button>
               </div>
             </section>

--- a/supabase/migrations/20250901130000_create_site_settings_table.sql
+++ b/supabase/migrations/20250901130000_create_site_settings_table.sql
@@ -1,0 +1,24 @@
+-- Create the site_settings table
+CREATE TABLE public.site_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.site_settings ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies for site_settings
+CREATE POLICY "Public can view all site settings"
+ON public.site_settings
+FOR SELECT
+USING (true);
+
+CREATE POLICY "Admins can manage site settings"
+ON public.site_settings
+FOR ALL
+USING (is_admin(auth.uid()))
+WITH CHECK (is_admin(auth.uid()));
+
+-- Insert a default value for the hero video URL
+INSERT INTO public.site_settings (key, value)
+VALUES ('homepage_hero_video_url', '');


### PR DESCRIPTION
This commit introduces a new hero section on the homepage, featuring an admin-uploaded video banner and a call-to-action button.

The changes include:
- A new `site_settings` table to store site-wide configurations, including the hero video URL.
- A new `SiteSettingsManagement` component in the admin panel to allow administrators to upload and manage the hero video.
- The homepage (`Index.tsx`) has been updated to display the new hero section with the video in a 16:9 aspect ratio and an "Earn" button that links to the contest page.