### PR TITLE
fix: Create public-assets bucket for hero video uploads

### DIFF
--- a/supabase/migrations/20250901140000_create_public_assets_bucket.sql
+++ b/supabase/migrations/20250901140000_create_public_assets_bucket.sql
@@ -1,0 +1,19 @@
+-- Create a new bucket for public assets if it doesn't exist
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('public-assets', 'public-assets', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Create RLS policies for the public-assets bucket
+
+-- Allow public read access to all files in the bucket
+CREATE POLICY "Public can view all assets"
+ON storage.objects
+FOR SELECT
+USING (bucket_id = 'public-assets');
+
+-- Allow authenticated admins to upload, update, and delete files
+CREATE POLICY "Admins can manage assets"
+ON storage.objects
+FOR ALL
+USING (bucket_id = 'public-assets' AND is_admin(auth.uid()))
+WITH CHECK (bucket_id = 'public-assets' AND is_admin(auth.uid()));


### PR DESCRIPTION
This commit fixes an issue where admins were unable to upload a hero section video due to a missing storage bucket.

The changes include:
- A new migration file to create the `public-assets` storage bucket if it doesn't exist.
- RLS policies for the `public-assets` bucket to allow public reads and admin-only writes.