### PR TITLE
Fix: Correct table name for site settings

### DIFF
--- a/src/components/admin/SiteSettingsManagement.tsx
+++ b/src/components/admin/SiteSettingsManagement.tsx
@@ -18,7 +18,7 @@ export const SiteSettingsManagement = () => {
     const fetchSettings = async () => {
       setLoading(true);
       const { data, error } = await supabase
-        .from('system_settings')
+        .from('site_settings')
         .select('value')
         .eq('key', 'homepage_hero_video_url')
         .single();
@@ -95,7 +95,7 @@ export const SiteSettingsManagement = () => {
 
       // Check if setting exists
       const { data: existingSetting } = await supabase
-        .from('system_settings')
+        .from('site_settings')
         .select('id')
         .eq('key', 'homepage_hero_video_url')
         .single();
@@ -103,7 +103,7 @@ export const SiteSettingsManagement = () => {
       if (existingSetting) {
         // Update existing setting
         const { error: updateError } = await supabase
-          .from('system_settings')
+          .from('site_settings')
           .update({ 
             value: publicUrl,
             updated_at: new Date().toISOString()
@@ -116,7 +116,7 @@ export const SiteSettingsManagement = () => {
       } else {
         // Insert new setting
         const { error: insertError } = await supabase
-          .from('system_settings')
+          .from('site_settings')
           .insert({
             key: 'homepage_hero_video_url',
             value: publicUrl,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -38,7 +38,7 @@ export default function Index() {
       try {
         console.log('Fetching hero video URL...');
         const { data, error } = await supabase
-          .from('system_settings')
+          .from('site_settings')
           .select('value')
           .eq('key', 'homepage_hero_video_url')
           .single();

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -68,7 +68,7 @@ export const defaultSettings: SystemSettings = {
 export const loadSystemSettings = async (): Promise<SystemSettings> => {
   try {
     const { data, error } = await supabase
-      .from('system_settings')
+      .from('site_settings')
       .select('key, value')
       .in('key', ['general', 'api', 'security', 'notifications', 'adminProfile']);
 
@@ -119,7 +119,7 @@ export const saveSystemSettings = async (settings: SystemSettings): Promise<void
 
     for (const setting of settingsToSave) {
       const { error } = await supabase
-        .from('system_settings')
+        .from('site_settings')
         .upsert({
           key: setting.key,
           value: setting.value,

--- a/supabase/migrations/20250901130000_create_site_settings_table.sql
+++ b/supabase/migrations/20250901130000_create_site_settings_table.sql
@@ -1,7 +1,12 @@
 -- Create the site_settings table
 CREATE TABLE public.site_settings (
-    key TEXT PRIMARY KEY,
-    value TEXT
+    id SERIAL PRIMARY KEY,
+    key TEXT UNIQUE NOT NULL,
+    value JSONB,
+    category TEXT,
+    description TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
 -- Enable Row Level Security
@@ -20,5 +25,5 @@ USING (is_admin(auth.uid()))
 WITH CHECK (is_admin(auth.uid()));
 
 -- Insert a default value for the hero video URL
-INSERT INTO public.site_settings (key, value)
-VALUES ('homepage_hero_video_url', '');
+INSERT INTO public.site_settings (key, value, category, description)
+VALUES ('homepage_hero_video_url', '""', 'site', 'Homepage hero section video URL');


### PR DESCRIPTION
- The application was using `system_settings` while the database migration was creating `site_settings`.
- This caused an issue where the hero video could not be uploaded, and the hero section was not visible on the home page.
- This commit corrects the table name in all relevant files to `site_settings` and updates the migration to create the table with the correct schema.