### PR TITLE
Fix: Correct data type for hero video URL

### DIFF
--- a/src/components/admin/SiteSettingsManagement.tsx
+++ b/src/components/admin/SiteSettingsManagement.tsx
@@ -105,7 +105,7 @@ export const SiteSettingsManagement = () => {
         const { error: updateError } = await supabase
           .from('site_settings')
           .update({ 
-            value: publicUrl,
+            value: { url: publicUrl },
             updated_at: new Date().toISOString()
           })
           .eq('key', 'homepage_hero_video_url');
@@ -119,7 +119,7 @@ export const SiteSettingsManagement = () => {
           .from('site_settings')
           .insert({
             key: 'homepage_hero_video_url',
-            value: publicUrl,
+            value: { url: publicUrl },
             category: 'site',
             description: 'Homepage hero section video URL'
           });

--- a/supabase/migrations/20250901130000_create_site_settings_table.sql
+++ b/supabase/migrations/20250901130000_create_site_settings_table.sql
@@ -26,4 +26,4 @@ WITH CHECK (is_admin(auth.uid()));
 
 -- Insert a default value for the hero video URL
 INSERT INTO public.site_settings (key, value, category, description)
-VALUES ('homepage_hero_video_url', '""', 'site', 'Homepage hero section video URL');
+VALUES ('homepage_hero_video_url', null, 'site', 'Homepage hero section video URL');


### PR DESCRIPTION
- This commit fixes a bug where the video upload would fail due to a data type mismatch.
- The `site_settings` table's `value` column is `JSONB`, but the application was sending a plain string for the video URL.
- The code has been updated to wrap the URL in a JSON object (`{ url: publicUrl }`) before saving, which aligns with the database schema.
- The default value in the migration has also been changed to `null` for better data quality.