### PR TITLE
fix(contest): Fix play button and unlock contest functionality

### DIFF
--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -141,7 +141,7 @@ const Contest = () => {
       toast.info('Please log in to unlock the contest.');
       return;
     }
-    await unlockContest(contest.id, contest.entry_fee);
+    await unlockContest(contest.id, Number(contest.entry_fee));
   };
 
   const canParticipate = isVoter() || isSubscriber() || userRoles.includes('admin') || userRoles.includes('super_admin');


### PR DESCRIPTION
This commit addresses two issues on the contest page:

1.  **Fixes the play button on contest entries.** The button was not working because it was attempting to use an incorrect data structure (`entry.songs.audio_url`) to find the media URL. The component has been updated to use the correct `entry.video_url` property from the `ContestEntry` object.

2.  **Fixes the "unlock contest" functionality.** This feature was broken due to a type mismatch. The `unlockContest` function was being called with an `entry_fee` that was not guaranteed to be a number. The code has been updated to explicitly cast the `entry_fee` to a `Number` before passing it to the function, resolving the issue.

Additionally, outdated local `Contest` and `ContestEntry` interfaces in `Contest.tsx` have been removed in favor of importing them from the `use-contest` hook for better code consistency.