### PR TITLE
fix: Resolve multiple contest page and database trigger issues

### DIFF
--- a/supabase/migrations/20250803150100_update_handle_new_user_with_referral_validation.sql
+++ b/supabase/migrations/20250803150100_update_handle_new_user_with_referral_validation.sql
@@ -11,6 +11,11 @@ DECLARE
   user_ip_address TEXT;
   referral_code_from_meta TEXT;
 BEGIN
+  -- If this trigger is fired by an UPDATE operation, do nothing.
+  IF TG_OP = 'UPDATE' THEN
+    RETURN NEW;
+  END IF;
+
   -- Extract data from new user object
   user_ip_address := NEW.last_sign_in_ip;
   user_device_id := NEW.raw_user_meta_data->>'device_id';


### PR DESCRIPTION
This commit addresses several issues related to the contest page and underlying database functions.

1.  **Fixes the play button on contest entries.** The button was not working because it was attempting to use an incorrect data structure (`entry.songs.audio_url`). The `Contest.tsx` component has been updated to use the correct `entry.video_url` property from the `ContestEntry` object.

2.  **Fixes the "unlock contest" functionality.** This feature was failing with a database error. The root cause was a database trigger (`handle_new_user`) that was incorrectly configured to fire on `UPDATE` operations on the `profiles` table. The trigger is intended to run only on `INSERT` (i.e., for new users). The migration file for the `handle_new_user` function has been updated to include a guard clause that prevents it from executing on `UPDATE` operations, resolving the error.

3.  **Improves code quality.** Outdated local `Contest` and `ContestEntry` interfaces in `Contest.tsx` have been removed in favor of importing them from the `use-contest` hook for better code consistency.