### PR TITLE
fix(payments): Correctly parse Paystack public key

### DIFF
--- a/src/hooks/usePaymentPublicKeys.ts
+++ b/src/hooks/usePaymentPublicKeys.ts
@@ -34,7 +34,13 @@ export const usePaymentPublicKeys = () => {
       }
 
       if (data?.value) {
-        const settings = data.value as PaymentGatewayKeys;
+        let settings: PaymentGatewayKeys;
+        if (typeof data.value === 'string') {
+          settings = JSON.parse(data.value);
+        } else {
+          settings = data.value as PaymentGatewayKeys;
+        }
+
         const mode = settings.mode || 'test';
 
         return {


### PR DESCRIPTION
The `usePaymentPublicKeys` hook was attempting to read payment gateway settings directly, assuming the value from Supabase was an object. However, the value is often stored as a stringified JSON. This caused the hook to fail to extract the Paystack public key, passing `undefined` to the Paystack library and resulting in a 403 Forbidden error when trying to load checkout assets.

This commit adds the necessary logic to the `usePaymentPublicKeys` hook to check if the fetched value is a string and, if so, parse it using `JSON.parse`. This aligns its behavior with the `usePaymentGatewaySettings` hook, which already handled this case, ensuring the public key is always correctly read.