### PR TITLE
feat: Add hover and click animations to interactive elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "gsap": "^3.13.0",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -4837,6 +4838,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "gsap": "^3.13.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/src/animations.css
+++ b/src/animations.css
@@ -1,0 +1,19 @@
+@layer components {
+  /* Hover Effects */
+  .hover-scale {
+    @apply transition-transform duration-200 ease-in-out hover:scale-105;
+  }
+
+  .hover-shadow {
+    @apply transition-shadow duration-300 ease-in-out hover:shadow-lg;
+  }
+
+  .hover-lift {
+    @apply transition-transform duration-300 ease-in-out hover:-translate-y-1;
+  }
+
+  /* Focus Effects */
+  .focus-ring {
+    @apply focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring;
+  }
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -27,7 +27,7 @@ const Navbar = ({ onMenuClick }: NavbarProps) => {
           <Button variant="ghost" size="icon" onClick={onMenuClick} className="md:hidden text-white/80 hover:bg-white/10 hover:text-white">
             <Menu className="h-5 w-5" />
           </Button>
-          <Link to="/dashboard" className="flex items-center gap-2">
+          <Link to="/dashboard" className="flex items-center gap-2 hover-scale">
             <Music className="h-6 w-6 text-dark-purple" />
             <span className="font-poppins font-bold text-xl text-white">Afroverse</span>
           </Link>
@@ -41,20 +41,20 @@ const Navbar = ({ onMenuClick }: NavbarProps) => {
             </Button>
           </Link>
 
-          <Link to="/billing" className="flex items-center mr-2 group">
+          <Link to="/billing" className="flex items-center mr-2 group hover-scale">
             <div className="flex items-center px-3 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 transition-colors">
               <Star className="h-4 w-4 text-yellow-400 mr-2 group-hover:scale-110 transition-transform" />
               <span className="text-sm font-medium text-white">{user?.credits ?? 0}</span>
             </div>
           </Link>
           
-          <Button variant="ghost" size="icon" className="text-white/80 hover:bg-white/10 hover:text-white rounded-full">
+          <Button variant="ghost" size="icon" className="text-white/80 hover:bg-white/10 hover:text-white rounded-full hover-scale">
             <Bell className="h-5 w-5" />
           </Button>
           
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="rounded-full">
+              <Button variant="ghost" size="icon" className="rounded-full hover-scale">
                 <Avatar className="h-8 w-8">
                   <AvatarImage src={user?.avatar || ""} />
                   <AvatarFallback className="text-sm bg-dark-purple text-white">{user?.name?.charAt(0) || "U"}</AvatarFallback>
@@ -63,12 +63,12 @@ const Navbar = ({ onMenuClick }: NavbarProps) => {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="bg-black/50 border-white/10 text-white backdrop-blur-lg">
               <DropdownMenuItem asChild>
-                <Link to="/profile" className="flex items-center cursor-pointer focus:bg-white/10">
+                <Link to="/profile" className="flex items-center cursor-pointer focus:bg-white/10 hover-scale">
                   <User className="mr-2 h-4 w-4" />
                   <span>Profile</span>
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleLogout} className="flex items-center cursor-pointer focus:bg-white/10 text-red-400 focus:text-red-400">
+              <DropdownMenuItem onClick={handleLogout} className="flex items-center cursor-pointer focus:bg-white/10 text-red-400 focus:text-red-400 hover-scale">
                 <LogOut className="mr-2 h-4 w-4" />
                 <span>Log out</span>
               </DropdownMenuItem>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,21 +1,26 @@
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import { useClickPop } from "@/hooks/use-click-pop"
 
 import { cn } from "@/lib/utils"
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, ...props }, ref) => {
+  const clickPopRef = useClickPop<HTMLSpanElement>()
+
+  return (
+    <AvatarPrimitive.Root
+      ref={clickPopRef}
+      className={cn(
+        "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full hover-scale",
+        className
+      )}
+      {...props}
+    />
+  )
+})
 Avatar.displayName = AvatarPrimitive.Root.displayName
 
 const AvatarImage = React.forwardRef<

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 hover-scale",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import { useClickPop } from "@/hooks/use-click-pop"
 
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover-lift [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -41,11 +42,13 @@ export interface ButtonProps
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const clickPopRef = useClickPop<HTMLButtonElement>()
+
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
+        ref={clickPopRef}
         {...props}
       />
     )

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,20 +1,25 @@
 import * as React from "react"
+import { useClickPop } from "@/hooks/use-click-pop"
 
 import { cn } from "@/lib/utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, ...props }, ref) => {
+  const clickPopRef = useClickPop<HTMLDivElement>()
+
+  return (
+    <div
+      ref={clickPopRef}
+      className={cn(
+        "rounded-lg border bg-card text-card-foreground shadow-sm hover-lift hover-shadow",
+        className
+      )}
+      {...props}
+    />
+  )
+})
 Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -72,22 +72,28 @@ const DropdownMenuContent = React.forwardRef<
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
+import { useClickPop } from "@/hooks/use-click-pop"
+
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean
   }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      inset && "pl-8",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, inset, ...props }, ref) => {
+  const clickPopRef = useClickPop<HTMLDivElement>()
+
+  return (
+    <DropdownMenuPrimitive.Item
+      ref={clickPopRef}
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 hover-scale",
+        inset && "pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+})
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
 const DropdownMenuCheckboxItem = React.forwardRef<

--- a/src/hooks/use-click-pop.ts
+++ b/src/hooks/use-click-pop.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { gsap } from 'gsap';
+
+export const useClickPop = <T extends HTMLElement>() => {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const handleClick = () => {
+      gsap.to(element, {
+        scale: 0.95,
+        yoyo: true,
+        repeat: 1,
+        duration: 0.1,
+        ease: 'power1.inOut',
+      });
+    };
+
+    element.addEventListener('click', handleClick);
+
+    return () => {
+      element.removeEventListener('click', handleClick);
+    };
+  }, []);
+
+  return ref;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+@import "./animations.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
This commit introduces a set of CSS-based hover effects and a GSAP-powered click animation to enhance the user experience of the application.

New CSS classes for hover effects (`hover-scale`, `hover-lift`, `hover-shadow`) have been added to `src/animations.css` and applied to various components.

A reusable `useClickPop` hook has been created to provide a consistent "click-pop" animation on buttons, cards, and other interactive elements.

GSAP has been added as a dependency to power the click animations.