### PR TITLE
Fix: Adjust genre card size and background color

### DIFF
--- a/src/components/dashboard/GenreTemplateCard.tsx
+++ b/src/components/dashboard/GenreTemplateCard.tsx
@@ -58,10 +58,10 @@ export const GenreTemplateCard = ({ template }: GenreTemplateCardProps) => {
 
   return (
     <Card
-      className="bg-gray-800/40 backdrop-blur-xl border border-purple-500/20 hover:border-purple-400 transition-all duration-300 ease-in-out transform hover:-translate-y-2 hover:shadow-xl hover:shadow-purple-500/30 flex flex-col"
+      className="bg-gray-900 border border-purple-500/20 hover:border-purple-400 transition-all duration-300 ease-in-out transform hover:-translate-y-2 hover:shadow-xl hover:shadow-purple-500/30 flex flex-col"
     >
       <img src={template.cover_image_url || '/placeholder.svg'} alt={template.template_name} className="w-full h-40 object-cover rounded-t-xl flex-shrink-0" />
-      <CardContent className="p-4 flex-grow">
+      <CardContent className="p-4">
         <h4 className="text-xl font-semibold mb-2">{template.template_name}</h4>
         <p className="text-sm text-gray-400 mb-4">{template.genres?.name || 'Template'}</p>
       </CardContent>
@@ -69,13 +69,13 @@ export const GenreTemplateCard = ({ template }: GenreTemplateCardProps) => {
         <div className="flex gap-3">
           <Button
             onClick={handleAudioPlay}
-            className="backdrop-blur-xl bg-white/10 border border-purple-400/30 text-purple-300 hover:bg-purple-400/20 flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-300 ease-in-out transform hover:scale-105 w-full justify-center"
+            className="bg-white/10 border border-purple-400/30 text-purple-300 hover:bg-purple-400/20 flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-300 ease-in-out transform hover:scale-105 w-full justify-center"
           >
             <Play size={16} /> {isPlaying ? "Pause" : "Preview"}
           </Button>
           <Button
             onClick={handleCreateMusic}
-            className="backdrop-blur-xl bg-white/10 border border-purple-400/30 text-purple-300 hover:bg-purple-400/20 px-4 py-2 rounded-xl transition-all duration-300 ease-in-out transform hover:scale-105 w-full justify-center"
+            className="bg-white/10 border border-purple-400/30 text-purple-300 hover:bg-purple-400/20 px-4 py-2 rounded-xl transition-all duration-300 ease-in-out transform hover:scale-105 w-full justify-center"
           >
             Use Template
           </Button>


### PR DESCRIPTION
This commit addresses user feedback on the genre template cards.

Key changes include:
- The cards are now more compact, as the content area no longer grows to fill the grid row.
- The card background has been changed to a solid color to avoid visual conflicts with the page's gradient background.
- The buttons within the card have had their backdrop-blur effect removed for design consistency.