### PR TITLE
Feat: Make sidebar minimalistic and add faint border

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -82,7 +82,6 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
                 }}
                 title={needsSubscription ? `${item.label} (Subscription required)` : item.label}
               >
-                <item.icon className={cn("mr-3 h-5 w-5 flex-shrink-0", isActive && "text-purple-400")} />
                 <span className="flex-grow text-left truncate">{effectiveLabel}</span>
                 {item.tag && !needsSubscription && (
                   <Badge variant="outline" className="ml-2 text-xs px-1.5 py-0.5 self-center border-dark-purple text-dark-purple">
@@ -100,7 +99,6 @@ const Sidebar: React.FC<SidebarProps> = ({ className }) => {
       {user && (
         <div className="mt-auto p-2 flex-shrink-0">
            <Button variant="ghost" className="w-full justify-start text-gray-300 hover:text-purple-400" onClick={() => navigate('/profile')}>
-             <User className="mr-3 h-5 w-5 flex-shrink-0" />
              <span className="truncate">{user.email?.split('@')[0] || user.id}</span>
            </Button>
         </div>

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -16,7 +16,7 @@ const AppLayoutContent = () => {
 
       {/* Mobile Sidebar */}
       <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-        <SheetContent side="left" className="w-60 p-0 flex flex-col bg-black">
+        <SheetContent side="left" className="w-60 p-0 flex flex-col bg-black border-r border-white/10">
           <Sidebar />
         </SheetContent>
       </Sheet>
@@ -24,7 +24,7 @@ const AppLayoutContent = () => {
       <div className="flex flex-1 overflow-hidden">
         {/* Desktop Sidebar */}
         <div className="hidden md:block flex-shrink-0">
-          <Sidebar className="bg-black" />
+          <Sidebar className="bg-black border-r border-white/10" />
         </div>
         <main className="flex-1 flex flex-col overflow-y-auto" style={{ paddingBottom: '120px' }}>
           <Outlet />


### PR DESCRIPTION
This commit addresses user feedback to make the sidebar more minimalistic and to demarcate it with a faint border.

Key changes include:
- Icons have been removed from the sidebar navigation links and the user profile button.
- A faint border (`border-r border-white/10`) has been added to the right side of the sidebar.