### PR TITLE
feat: Implement hero video upload feature

### DIFF
--- a/src/utils/storageSetup.ts
+++ b/src/utils/storageSetup.ts
@@ -11,17 +11,31 @@ export const ensureStorageBuckets = async () => {
       return;
     }
 
-    const contestBucketExists = buckets?.some(bucket => bucket.name === 'contest-videos');
-    
-    if (!contestBucketExists) {
-      const { error: createError } = await supabase.storage.createBucket('contest-videos', {
-        public: true,
-        allowedMimeTypes: ['video/mp4', 'video/avi', 'video/mov', 'video/wmv'],
-        fileSizeLimit: 50 * 1024 * 1024 // 50MB
-      });
-      
-      if (createError) {
-        console.error('Error creating contest-videos bucket:', createError);
+    const requiredBuckets = [
+      {
+        name: 'contest-videos',
+        options: {
+          public: true,
+          allowedMimeTypes: ['video/mp4', 'video/avi', 'video/mov', 'video/wmv'],
+          fileSizeLimit: 50 * 1024 * 1024 // 50MB
+        }
+      },
+      {
+        name: 'site-content',
+        options: {
+          public: true,
+          fileSizeLimit: 50 * 1024 * 1024 // 50MB
+        }
+      }
+    ];
+
+    for (const bucket of requiredBuckets) {
+      const bucketExists = buckets?.some(b => b.name === bucket.name);
+      if (!bucketExists) {
+        const { error: createError } = await supabase.storage.createBucket(bucket.name, bucket.options);
+        if (createError) {
+          console.error(`Error creating ${bucket.name} bucket:`, createError);
+        }
       }
     }
   } catch (error) {

--- a/supabase/migrations/20250906235700_create_settings_table.sql
+++ b/supabase/migrations/20250906235700_create_settings_table.sql
@@ -1,0 +1,22 @@
+-- Create the settings table
+CREATE TABLE IF NOT EXISTS public.settings (
+  key TEXT PRIMARY KEY,
+  value JSONB
+);
+
+-- Enable Row Level Security for the settings table
+ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
+
+-- Create a policy to allow public read access
+CREATE POLICY "Allow public read access to settings"
+ON public.settings FOR SELECT
+TO anon, authenticated
+USING (true);
+
+-- Create a policy to allow authenticated users to manage settings
+-- Create a policy to allow admin users to manage settings
+CREATE POLICY "Allow admin users to manage settings"
+ON public.settings FOR ALL
+TO authenticated
+USING ((get_my_claim('user_role'::text) = '"admin"'::jsonb))
+WITH CHECK ((get_my_claim('user_role'::text) = '"admin"'::jsonb));


### PR DESCRIPTION
- Add a new `settings` table to the database to store key-value pairs for site settings.
- Add a new `site-content` storage bucket for storing public assets like the hero video.
- Implement a form in the admin panel for uploading a new hero video.
- Update the hero section on the homepage to use the dynamic video URL from the `settings` table.