### PR TITLE
feat: Implement hero video upload feature and handle bucket creation …

### DIFF
--- a/supabase/migrations/20250906235700_create_settings_table.sql
+++ b/supabase/migrations/20250906235700_create_settings_table.sql
@@ -1,0 +1,22 @@
+-- Create the settings table
+CREATE TABLE IF NOT EXISTS public.settings (
+  key TEXT PRIMARY KEY,
+  value JSONB
+);
+
+-- Enable Row Level Security for the settings table
+ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
+
+-- Create a policy to allow public read access
+CREATE POLICY "Allow public read access to settings"
+ON public.settings FOR SELECT
+TO anon, authenticated
+USING (true);
+
+-- Create a policy to allow authenticated users to manage settings
+-- Create a policy to allow admin users to manage settings
+CREATE POLICY "Allow admin users to manage settings"
+ON public.settings FOR ALL
+TO authenticated
+USING ((get_my_claim('user_role'::text) = '"admin"'::jsonb))
+WITH CHECK ((get_my_claim('user_role'::text) = '"admin"'::jsonb));


### PR DESCRIPTION
…race condition

- Add a new `settings` table to the database to store key-value pairs for site settings.
- Add a new `site-content` storage bucket for storing public assets like the hero video.
- Implement a form in the admin panel for uploading a new hero video.
- Update the hero section on the homepage to use the dynamic video URL from the `settings` table.
- Handle the `BucketAlreadyExists` error gracefully to prevent log spam from race conditions.