### PR TITLE
feat: Implement admin hero video upload feature

### DIFF
--- a/src/components/admin/HeroVideoUploadForm.tsx
+++ b/src/components/admin/HeroVideoUploadForm.tsx
@@ -13,6 +13,12 @@ export const HeroVideoUploadForm = () => {
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0) {
+      if (event.target.files[0].type !== 'video/mp4') {
+        toast.error('Please select a valid .mp4 video file.');
+        setVideoFile(null);
+        event.target.value = ''; // Reset the file input
+        return;
+      }
       setVideoFile(event.target.files[0]);
     }
   };
@@ -25,15 +31,19 @@ export const HeroVideoUploadForm = () => {
 
     setUploading(true);
     try {
-      const filePath = `public/hero-video.mp4`;
+      // Use a unique name for the file to avoid conflicts
+      const fileName = `hero-video-${Date.now()}.mp4`;
+      const filePath = `public/${fileName}`;
+
       const { error: uploadError } = await supabase.storage
         .from('site-content')
         .upload(filePath, videoFile, {
-          upsert: true, // Overwrite if it already exists
+          cacheControl: '3600',
+          upsert: false,
         });
 
       if (uploadError) {
-        throw uploadError;
+        throw new Error(`Upload failed: ${uploadError.message}`);
       }
 
       const { data: publicUrlData } = supabase.storage
@@ -44,7 +54,12 @@ export const HeroVideoUploadForm = () => {
         throw new Error('Could not get public URL for the uploaded video.');
       }
 
-      const success = await updateSetting('heroVideoUrl', publicUrlData.publicUrl);
+      const publicUrl = publicUrlData.publicUrl;
+
+      // To ensure the URL is always fresh, let's append a timestamp
+      const urlWithTimestamp = `${publicUrl}?t=${new Date().getTime()}`;
+
+      const success = await updateSetting('heroVideoUrl', urlWithTimestamp);
 
       if (success) {
         toast.success('Hero video uploaded and setting updated successfully!');
@@ -53,7 +68,7 @@ export const HeroVideoUploadForm = () => {
       }
 
     } catch (error: any) {
-      toast.error(error.message || 'Failed to upload video.');
+      toast.error(error.message || 'An unexpected error occurred during upload.');
     } finally {
       setUploading(false);
     }
@@ -64,12 +79,12 @@ export const HeroVideoUploadForm = () => {
       <CardHeader>
         <CardTitle>Hero Section Video</CardTitle>
         <CardDescription>
-          Upload a new video for the hero section of the homepage. The current video will be replaced.
+          Upload a new .mp4 video for the hero section of the homepage. The current video will be replaced.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div>
-          <Label htmlFor="hero-video-file">Video File (MP4)</Label>
+          <Label htmlFor="hero-video-file">Video File (MP4 only)</Label>
           <Input id="hero-video-file" type="file" accept="video/mp4" onChange={handleFileChange} />
         </div>
         <Button onClick={handleUpload} disabled={uploading || !videoFile}>

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -136,7 +136,6 @@ const Admin = ({ tab }: AdminProps) => {
               <TabsTrigger value="support">Support</TabsTrigger>
               <TabsTrigger value="reports">Reports</TabsTrigger>
               <TabsTrigger value="settings">Settings</TabsTrigger>
-              <TabsTrigger value="site-settings">Site Settings</TabsTrigger>
               <TabsTrigger value="affiliates">Affiliates</TabsTrigger>
             </TabsList>
           </div>
@@ -321,6 +320,7 @@ const Admin = ({ tab }: AdminProps) => {
           </TabsContent>
 
           <TabsContent value="content" className="space-y-4">
+            <HeroVideoUploadForm />
             <Card className="bg-card">
               <CardHeader>
                 <CardTitle>Content Management</CardTitle>
@@ -376,18 +376,6 @@ const Admin = ({ tab }: AdminProps) => {
               </CardHeader>
               <CardContent>
                 <SettingsManagement />
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="site-settings" className="space-y-4">
-            <Card className="bg-card">
-              <CardHeader>
-                <CardTitle>Site Settings</CardTitle>
-                <CardDescription>Manage site-wide settings</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <HeroVideoUploadForm />
               </CardContent>
             </Card>
           </TabsContent>

--- a/supabase/migrations/20250907010801_create_settings_table.sql
+++ b/supabase/migrations/20250907010801_create_settings_table.sql
@@ -1,0 +1,21 @@
+-- Create the settings table
+CREATE TABLE IF NOT EXISTS public.settings (
+  key TEXT PRIMARY KEY,
+  value JSONB
+);
+
+-- Enable Row Level Security for the settings table
+ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
+
+-- Create a policy to allow public read access
+CREATE POLICY "Allow public read access to settings"
+ON public.settings FOR SELECT
+TO anon, authenticated
+USING (true);
+
+-- Create a policy to allow admin users to manage settings
+CREATE POLICY "Allow admin users to manage settings"
+ON public.settings FOR ALL
+TO authenticated
+USING ((get_my_claim('user_role'::text) = '"admin"'::jsonb))
+WITH CHECK ((get_my_claim('user_role'::text) = '"admin"'::jsonb));

--- a/supabase/migrations/20250907010819_setup_storage_for_site_content.sql
+++ b/supabase/migrations/20250907010819_setup_storage_for_site_content.sql
@@ -1,0 +1,36 @@
+-- Create site-content bucket if it doesn't exist
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('site-content', 'site-content', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- RLS policy for bucket creation
+DROP POLICY IF EXISTS "Allow authenticated users to create buckets" ON storage.buckets;
+CREATE POLICY "Allow authenticated users to create buckets"
+ON storage.buckets FOR INSERT
+TO authenticated
+WITH CHECK (true);
+
+-- RLS policies for site-content bucket objects
+DROP POLICY IF EXISTS "Allow admin uploads to site-content" ON storage.objects;
+CREATE POLICY "Allow admin uploads to site-content"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'site-content' AND
+  (get_my_claim('user_role'::text) = '"admin"'::jsonb)
+);
+
+DROP POLICY IF EXISTS "Allow admin updates to site-content" ON storage.objects;
+CREATE POLICY "Allow admin updates to site-content"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'site-content' AND
+  (get_my_claim('user_role'::text) = '"admin"'::jsonb)
+);
+
+DROP POLICY IF EXISTS "Allow public read access to site-content" ON storage.objects;
+CREATE POLICY "Allow public read access to site-content"
+ON storage.objects FOR SELECT
+TO anon, authenticated
+USING ( bucket_id = 'site-content' );


### PR DESCRIPTION
This commit introduces a complete, end-to-end feature for a dynamic, admin-manageable hero section video.

- Creates a `settings` table to store key-value pairs for site settings, including the `heroVideoUrl`.
- Sets up the `site-content` storage bucket and all necessary RLS policies for bucket creation, admin uploads, and public reads.
- Implements an improved `HeroVideoUploadForm` component with file type validation, unique naming for cache-busting, and better error handling.
- Integrates the upload form into the "Content" tab of the admin panel for easy access.
- The existing `HeroSection` component was already configured to fetch the dynamic URL from the `settings` table.