### PR TITLE
fix: Add RLS policy for listing storage buckets

### DIFF
--- a/supabase/migrations/20250907010819_setup_storage_for_site_content.sql
+++ b/supabase/migrations/20250907010819_setup_storage_for_site_content.sql
@@ -10,6 +10,12 @@ ON storage.buckets FOR INSERT
 TO authenticated
 WITH CHECK (true);
 
+DROP POLICY IF EXISTS "Allow authenticated users to list buckets" ON storage.buckets;
+CREATE POLICY "Allow authenticated users to list buckets"
+ON storage.buckets FOR SELECT
+TO authenticated
+USING (true);
+
 -- RLS policies for site-content bucket objects
 DROP POLICY IF EXISTS "Allow admin uploads to site-content" ON storage.objects;
 CREATE POLICY "Allow admin uploads to site-content"


### PR DESCRIPTION
This change adds a new RLS policy to allow authenticated users to list storage buckets. This prevents an error where the application would try to create a bucket that already exists because it could not see it in the list of buckets.