### PR TITLE
feat: Implement admin hero video upload feature

### DIFF
--- a/src/components/admin/HeroVideoUploadForm.tsx
+++ b/src/components/admin/HeroVideoUploadForm.tsx
@@ -13,6 +13,12 @@ export const HeroVideoUploadForm = () => {
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0) {
+      if (event.target.files[0].type !== 'video/mp4') {
+        toast.error('Please select a valid .mp4 video file.');
+        setVideoFile(null);
+        event.target.value = ''; // Reset the file input
+        return;
+      }
       setVideoFile(event.target.files[0]);
     }
   };
@@ -25,15 +31,19 @@ export const HeroVideoUploadForm = () => {
 
     setUploading(true);
     try {
-      const filePath = `public/hero-video.mp4`;
+      // Use a unique name for the file to avoid conflicts
+      const fileName = `hero-video-${Date.now()}.mp4`;
+      const filePath = `public/${fileName}`;
+
       const { error: uploadError } = await supabase.storage
         .from('site-content')
         .upload(filePath, videoFile, {
-          upsert: true, // Overwrite if it already exists
+          cacheControl: '3600',
+          upsert: false,
         });
 
       if (uploadError) {
-        throw uploadError;
+        throw new Error(`Upload failed: ${uploadError.message}`);
       }
 
       const { data: publicUrlData } = supabase.storage
@@ -44,7 +54,12 @@ export const HeroVideoUploadForm = () => {
         throw new Error('Could not get public URL for the uploaded video.');
       }
 
-      const success = await updateSetting('heroVideoUrl', publicUrlData.publicUrl);
+      const publicUrl = publicUrlData.publicUrl;
+
+      // To ensure the URL is always fresh, let's append a timestamp
+      const urlWithTimestamp = `${publicUrl}?t=${new Date().getTime()}`;
+
+      const success = await updateSetting('heroVideoUrl', urlWithTimestamp);
 
       if (success) {
         toast.success('Hero video uploaded and setting updated successfully!');
@@ -53,7 +68,7 @@ export const HeroVideoUploadForm = () => {
       }
 
     } catch (error: any) {
-      toast.error(error.message || 'Failed to upload video.');
+      toast.error(error.message || 'An unexpected error occurred during upload.');
     } finally {
       setUploading(false);
     }
@@ -64,12 +79,12 @@ export const HeroVideoUploadForm = () => {
       <CardHeader>
         <CardTitle>Hero Section Video</CardTitle>
         <CardDescription>
-          Upload a new video for the hero section of the homepage. The current video will be replaced.
+          Upload a new .mp4 video for the hero section of the homepage. The current video will be replaced.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div>
-          <Label htmlFor="hero-video-file">Video File (MP4)</Label>
+          <Label htmlFor="hero-video-file">Video File (MP4 only)</Label>
           <Input id="hero-video-file" type="file" accept="video/mp4" onChange={handleFileChange} />
         </div>
         <Button onClick={handleUpload} disabled={uploading || !videoFile}>

--- a/supabase/migrations/20250907013845_setup_storage_for_site_content.sql
+++ b/supabase/migrations/20250907013845_setup_storage_for_site_content.sql
@@ -1,0 +1,43 @@
+-- Create site-content bucket if it doesn't exist
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('site-content', 'site-content', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- RLS policy for bucket creation
+DROP POLICY IF EXISTS "Allow authenticated users to create buckets" ON storage.buckets;
+CREATE POLICY "Allow authenticated users to create buckets"
+ON storage.buckets FOR INSERT
+TO authenticated
+WITH CHECK (true);
+
+-- RLS policy for listing buckets
+DROP POLICY IF EXISTS "Allow authenticated users to list buckets" ON storage.buckets;
+CREATE POLICY "Allow authenticated users to list buckets"
+ON storage.buckets FOR SELECT
+TO authenticated
+USING (true);
+
+-- RLS policies for site-content bucket objects
+DROP POLICY IF EXISTS "Allow admin uploads to site-content" ON storage.objects;
+CREATE POLICY "Allow admin uploads to site-content"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'site-content' AND
+  (get_my_claim('user_role'::text) = '"admin"'::jsonb)
+);
+
+DROP POLICY IF EXISTS "Allow admin updates to site-content" ON storage.objects;
+CREATE POLICY "Allow admin updates to site-content"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'site-content' AND
+  (get_my_claim('user_role'::text) = '"admin"'::jsonb)
+);
+
+DROP POLICY IF EXISTS "Allow public read access to site-content" ON storage.objects;
+CREATE POLICY "Allow public read access to site-content"
+ON storage.objects FOR SELECT
+TO anon, authenticated
+USING ( bucket_id = 'site-content' );


### PR DESCRIPTION
This commit introduces a complete, end-to-end feature for a dynamic, admin-manageable hero section video.

- Creates a `settings` table to store key-value pairs for site settings, including the `heroVideoUrl`.
- Sets up the `site-content` storage bucket and all necessary RLS policies for bucket creation, admin uploads, and public reads.
- Implements an improved `HeroVideoUploadForm` component with file type validation, unique naming for cache-busting, and better error handling.
- Integrates the upload form into a dedicated "Site Settings" tab in the admin panel as per the user's request.
- The existing `HeroSection` component is already configured to fetch the dynamic URL from the `settings` table.
- This submission includes a cleanup of duplicate migration files caused by an environment issue.