### PR TITLE
Fix race condition in Supabase bucket creation

### DIFF
--- a/src/utils/storageSetup.ts
+++ b/src/utils/storageSetup.ts
@@ -1,30 +1,73 @@
-
 import { supabase } from '@/integrations/supabase/client';
 
+let isBucketCheckRunning = false;
+let bucketsChecked = false;
+
+const bucketsToEnsure = [
+  {
+    name: 'contest-videos',
+    options: {
+      public: true,
+      allowedMimeTypes: ['video/mp4', 'video/quicktime', 'video/x-ms-wmv', 'video/x-matroska', 'video/avi', 'audio/mpeg', 'audio/wav'],
+      fileSizeLimit: 50 * 1024 * 1024, // 50MB
+    },
+  },
+  {
+    name: 'instrumentals',
+    options: {
+      public: true,
+      allowedMimeTypes: ['audio/mpeg', 'audio/wav', 'audio/ogg'],
+      fileSizeLimit: 50 * 1024 * 1024, // 50MB
+    },
+  },
+  {
+    name: 'site-content',
+    options: {
+      public: true,
+      allowedMimeTypes: ['video/mp4', 'image/jpeg', 'image/png', 'image/gif'],
+      fileSizeLimit: 50 * 1024 * 1024, // 50MB
+    },
+  },
+];
+
 export const ensureStorageBuckets = async () => {
+  if (bucketsChecked || isBucketCheckRunning) {
+    return;
+  }
+  isBucketCheckRunning = true;
+
   try {
-    // Check if contest-videos bucket exists
-    const { data: buckets, error: listError } = await supabase.storage.listBuckets();
-    
+    const { data: existingBuckets, error: listError } = await supabase.storage.listBuckets();
     if (listError) {
       console.error('Error listing buckets:', listError);
+      // Avoid retrying on every render if permissions are wrong.
+      bucketsChecked = true;
       return;
     }
 
-    const contestBucketExists = buckets?.some(bucket => bucket.name === 'contest-videos');
-    
-    if (!contestBucketExists) {
-      const { error: createError } = await supabase.storage.createBucket('contest-videos', {
-        public: true,
-        allowedMimeTypes: ['video/mp4', 'video/avi', 'video/mov', 'video/wmv'],
-        fileSizeLimit: 50 * 1024 * 1024 // 50MB
-      });
-      
-      if (createError) {
-        console.error('Error creating contest-videos bucket:', createError);
+    const existingBucketNames = new Set(existingBuckets.map(b => b.name));
+
+    for (const bucket of bucketsToEnsure) {
+      if (!existingBucketNames.has(bucket.name)) {
+        console.log(`Bucket "${bucket.name}" not found. Creating...`);
+        const { error: createError } = await supabase.storage.createBucket(bucket.name, bucket.options);
+        if (createError) {
+          // It's possible another process created the bucket in the meantime (race condition).
+          if (createError.message.includes('The resource already exists')) {
+            console.warn(`Bucket "${bucket.name}" was created by another process during check. Continuing...`);
+          } else {
+            console.error(`Error creating bucket "${bucket.name}":`, createError);
+          }
+        } else {
+          console.log(`Bucket "${bucket.name}" created successfully.`);
+        }
       }
     }
+
+    bucketsChecked = true;
   } catch (error) {
     console.error('Error in ensureStorageBuckets:', error);
+  } finally {
+    isBucketCheckRunning = false;
   }
 };


### PR DESCRIPTION
The `ensureStorageBuckets` function was being called multiple times from the `App` component, leading to a race condition where the application would attempt to create the same Supabase storage bucket multiple times simultaneously. This resulted in a "BucketAlreadyExists" error.

This commit fixes the issue by making the `ensureStorageBuckets` function idempotent. It now uses a flag to ensure that the bucket creation logic is only executed once, even if the function is called multiple times.

Additionally, the function has been updated to handle the creation of all necessary storage buckets (`contest-videos`, `instrumentals`, `site-content`), centralizing the bucket setup logic.