### PR TITLE
Fix hero video not displaying after upload

### DIFF
--- a/src/components/dashboard/HeroSection.tsx
+++ b/src/components/dashboard/HeroSection.tsx
@@ -15,6 +15,7 @@ export default function HeroSection() {
   } | null>(null);
   const [heroVideoUrl, setHeroVideoUrl] = useState('/hero-video.mp4');
 
+  // Fetch the hero video URL when the component mounts
   useEffect(() => {
     const fetchHeroVideo = async () => {
       const url = await getSetting('heroVideoUrl');
@@ -23,7 +24,9 @@ export default function HeroSection() {
       }
     };
     fetchHeroVideo();
+  }, []);
 
+  useEffect(() => {
     const featuredContest = activeContests[0] || upcomingContests[0];
     if (!featuredContest) {
       setContestStatus(null);


### PR DESCRIPTION
After a new hero video was uploaded, it was not being displayed on the homepage. This was because the `HeroSection` component was not refetching the video URL from the database after it was updated.

This commit fixes the issue by moving the logic to fetch the hero video URL into its own `useEffect` hook with an empty dependency array. This ensures that the component always fetches the latest video URL when it mounts.