### PR TITLE
Fix hero video not displaying due to RLS policy

### DIFF
--- a/src/utils/settingsOperations.ts
+++ b/src/utils/settingsOperations.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 export const getSetting = async (key: string): Promise<string | null> => {
   try {
     const { data, error } = await supabase
-      .from('settings')
+      .from('system_settings')
       .select('value')
       .eq('key', key)
       .single();
@@ -23,7 +23,7 @@ export const getSetting = async (key: string): Promise<string | null> => {
 export const updateSetting = async (key: string, value: string): Promise<boolean> => {
   try {
     const { error } = await supabase
-      .from('settings')
+      .from('system_settings')
       .upsert({ key, value }, { onConflict: 'key' });
 
     if (error) {

--- a/supabase/migrations/20250907031100_add_rls_for_public_settings.sql
+++ b/supabase/migrations/20250907031100_add_rls_for_public_settings.sql
@@ -1,0 +1,5 @@
+CREATE POLICY "Allow public read access to specific settings"
+ON public.system_settings
+FOR SELECT
+TO authenticated, anon
+USING (key = 'heroVideoUrl');


### PR DESCRIPTION
The hero video was not being displayed on the homepage because the frontend was unable to fetch the video URL from the database. This was caused by two issues:
1. The frontend was querying the `settings` table, but the correct table name is `system_settings`.
2. An RLS policy on the `system_settings` table was preventing non-admin users from reading the settings.

This commit fixes both issues. It updates the frontend code to use the correct table name and adds a new migration to create an RLS policy that allows public read access to the `heroVideoUrl` setting.