### PR TITLE
feat: End-to-end fix for hero video feature

### DIFF
--- a/supabase/migrations/20250907034700_create_is_admin_function.sql
+++ b/supabase/migrations/20250907034700_create_is_admin_function.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION is_admin(p_user_id UUID)
+RETURNS BOOLEAN AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles
+    WHERE user_id = p_user_id
+    AND role IN ('admin', 'super_admin')
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20250907034800_update_admin_rls_policy.sql
+++ b/supabase/migrations/20250907034800_update_admin_rls_policy.sql
@@ -1,0 +1,10 @@
+-- Drop the old policy that has the logic directly embedded
+DROP POLICY IF EXISTS "Admins can manage system settings" ON public.system_settings;
+
+-- Create a new policy that uses the is_admin() function
+CREATE POLICY "Admins can manage system settings"
+ON public.system_settings
+FOR ALL
+TO authenticated
+USING (is_admin(auth.uid()))
+WITH CHECK (is_admin(auth.uid()));


### PR DESCRIPTION
This commit provides a comprehensive fix for the hero video upload and display feature. The original issue was a "Bad Request" error during upload, which was caused by a race condition in storage bucket creation. Subsequent issues prevented the video from being displayed even after a successful upload.

The following fixes are included:
- **Storage:** The `ensureStorageBuckets` function is now idempotent, preventing race conditions during initial setup. It also handles the creation of all necessary buckets (`site-content`, `contest-videos`, `instrumentals`).
- **Database Schema:**
    - A missing `is_admin()` SQL function has been created. This function is critical for the RLS policies that protect the `system_settings` table.
    - The RLS policy for admin access to `system_settings` has been updated to use the new `is_admin()` function, ensuring that admins can correctly write to the table.
    - A new RLS policy has been added to allow public read access to the `heroVideoUrl` setting, so that all users can view the video.
- **Frontend:**
    - The `settingsOperations.ts` utility has been corrected to use the `system_settings` table instead of the non-existent `settings` table.
    - The `HeroSection.tsx` component now correctly fetches the video URL on component mount.