### PR TITLE
feat: End-to-end fix for hero video feature

### DIFF
--- a/src/components/admin/HeroVideoUploadForm.tsx
+++ b/src/components/admin/HeroVideoUploadForm.tsx
@@ -44,7 +44,7 @@ export const HeroVideoUploadForm = () => {
         throw new Error('Could not get public URL for the uploaded video.');
       }
 
-      const success = await updateSetting('heroVideoUrl', publicUrlData.publicUrl);
+      const success = await updateSetting('heroVideoUrl', publicUrlData.publicUrl, 'site_content');
 
       if (success) {
         toast.success('Hero video uploaded and setting updated successfully!');

--- a/src/components/dashboard/HeroSection.tsx
+++ b/src/components/dashboard/HeroSection.tsx
@@ -15,6 +15,7 @@ export default function HeroSection() {
   } | null>(null);
   const [heroVideoUrl, setHeroVideoUrl] = useState('/hero-video.mp4');
 
+  // Fetch the hero video URL when the component mounts
   useEffect(() => {
     const fetchHeroVideo = async () => {
       const url = await getSetting('heroVideoUrl');
@@ -23,7 +24,9 @@ export default function HeroSection() {
       }
     };
     fetchHeroVideo();
+  }, []);
 
+  useEffect(() => {
     const featuredContest = activeContests[0] || upcomingContests[0];
     if (!featuredContest) {
       setContestStatus(null);

--- a/src/utils/settingsOperations.ts
+++ b/src/utils/settingsOperations.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 export const getSetting = async (key: string): Promise<string | null> => {
   try {
     const { data, error } = await supabase
-      .from('settings')
+      .from('system_settings')
       .select('value')
       .eq('key', key)
       .single();
@@ -20,11 +20,11 @@ export const getSetting = async (key: string): Promise<string | null> => {
   }
 };
 
-export const updateSetting = async (key: string, value: string): Promise<boolean> => {
+export const updateSetting = async (key: string, value: string, category: string): Promise<boolean> => {
   try {
     const { error } = await supabase
-      .from('settings')
-      .upsert({ key, value }, { onConflict: 'key' });
+      .from('system_settings')
+      .upsert({ key, value, category }, { onConflict: 'key' });
 
     if (error) {
       console.error(`Error updating setting ${key}:`, error);

--- a/src/utils/storageSetup.ts
+++ b/src/utils/storageSetup.ts
@@ -1,30 +1,73 @@
-
 import { supabase } from '@/integrations/supabase/client';
 
+let isBucketCheckRunning = false;
+let bucketsChecked = false;
+
+const bucketsToEnsure = [
+  {
+    name: 'contest-videos',
+    options: {
+      public: true,
+      allowedMimeTypes: ['video/mp4', 'video/quicktime', 'video/x-ms-wmv', 'video/x-matroska', 'video/avi', 'audio/mpeg', 'audio/wav'],
+      fileSizeLimit: 50 * 1024 * 1024, // 50MB
+    },
+  },
+  {
+    name: 'instrumentals',
+    options: {
+      public: true,
+      allowedMimeTypes: ['audio/mpeg', 'audio/wav', 'audio/ogg'],
+      fileSizeLimit: 50 * 1024 * 1024, // 50MB
+    },
+  },
+  {
+    name: 'site-content',
+    options: {
+      public: true,
+      allowedMimeTypes: ['video/mp4', 'image/jpeg', 'image/png', 'image/gif'],
+      fileSizeLimit: 50 * 1024 * 1024, // 50MB
+    },
+  },
+];
+
 export const ensureStorageBuckets = async () => {
+  if (bucketsChecked || isBucketCheckRunning) {
+    return;
+  }
+  isBucketCheckRunning = true;
+
   try {
-    // Check if contest-videos bucket exists
-    const { data: buckets, error: listError } = await supabase.storage.listBuckets();
-    
+    const { data: existingBuckets, error: listError } = await supabase.storage.listBuckets();
     if (listError) {
       console.error('Error listing buckets:', listError);
+      // Avoid retrying on every render if permissions are wrong.
+      bucketsChecked = true;
       return;
     }
 
-    const contestBucketExists = buckets?.some(bucket => bucket.name === 'contest-videos');
-    
-    if (!contestBucketExists) {
-      const { error: createError } = await supabase.storage.createBucket('contest-videos', {
-        public: true,
-        allowedMimeTypes: ['video/mp4', 'video/avi', 'video/mov', 'video/wmv'],
-        fileSizeLimit: 50 * 1024 * 1024 // 50MB
-      });
-      
-      if (createError) {
-        console.error('Error creating contest-videos bucket:', createError);
+    const existingBucketNames = new Set(existingBuckets.map(b => b.name));
+
+    for (const bucket of bucketsToEnsure) {
+      if (!existingBucketNames.has(bucket.name)) {
+        console.log(`Bucket "${bucket.name}" not found. Creating...`);
+        const { error: createError } = await supabase.storage.createBucket(bucket.name, bucket.options);
+        if (createError) {
+          // It's possible another process created the bucket in the meantime (race condition).
+          if (createError.message.includes('The resource already exists')) {
+            console.warn(`Bucket "${bucket.name}" was created by another process during check. Continuing...`);
+          } else {
+            console.error(`Error creating bucket "${bucket.name}":`, createError);
+          }
+        } else {
+          console.log(`Bucket "${bucket.name}" created successfully.`);
+        }
       }
     }
+
+    bucketsChecked = true;
   } catch (error) {
     console.error('Error in ensureStorageBuckets:', error);
+  } finally {
+    isBucketCheckRunning = false;
   }
 };

--- a/supabase/migrations/20250907031100_add_rls_for_public_settings.sql
+++ b/supabase/migrations/20250907031100_add_rls_for_public_settings.sql
@@ -1,0 +1,5 @@
+CREATE POLICY "Allow public read access to specific settings"
+ON public.system_settings
+FOR SELECT
+TO authenticated, anon
+USING (key = 'heroVideoUrl');

--- a/supabase/migrations/20250907034700_create_is_admin_function.sql
+++ b/supabase/migrations/20250907034700_create_is_admin_function.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION is_admin(p_user_id UUID)
+RETURNS BOOLEAN AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.user_roles
+    WHERE user_id = p_user_id
+    AND role IN ('admin', 'super_admin')
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/20250907034800_update_admin_rls_policy.sql
+++ b/supabase/migrations/20250907034800_update_admin_rls_policy.sql
@@ -1,0 +1,10 @@
+-- Drop the old policy that has the logic directly embedded
+DROP POLICY IF EXISTS "Admins can manage system settings" ON public.system_settings;
+
+-- Create a new policy that uses the is_admin() function
+CREATE POLICY "Admins can manage system settings"
+ON public.system_settings
+FOR ALL
+TO authenticated
+USING (is_admin(auth.uid()))
+WITH CHECK (is_admin(auth.uid()));


### PR DESCRIPTION
This commit provides a comprehensive fix for the hero video upload and display feature. The original issue was a "Bad Request" error during upload, which was caused by a race condition in storage bucket creation. Subsequent issues prevented the video from being displayed even after a successful upload.

The following fixes are included:
- **Storage:** The `ensureStorageBuckets` function is now idempotent, preventing race conditions during initial setup. It also handles the creation of all necessary buckets (`site-content`, `contest-videos`, `instrumentals`).
- **Database Schema:**
    - A missing `is_admin()` SQL function has been created. This function is critical for the RLS policies that protect the `system_settings` table.
    - The RLS policy for admin access to `system_settings` has been updated to use the new `is_admin()` function, ensuring that admins can correctly write to the table.
    - A new RLS policy has been added to allow public read access to the `heroVideoUrl` setting, so that all users can view the video.
- **Frontend:**
    - The `settingsOperations.ts` utility has been corrected to use the `system_settings` table instead of the non-existent `settings` table.
    - The `HeroSection.tsx` component now correctly fetches the video URL on component mount.
    - The `updateSetting` function and its call site have been updated to include the `category` field, satisfying a `NOT NULL` constraint in the database.