### PR TITLE
fix: Create settings table and align video URL key and format

### DIFF
--- a/src/components/admin/HeroVideoUploadForm.tsx
+++ b/src/components/admin/HeroVideoUploadForm.tsx
@@ -48,7 +48,7 @@ export const HeroVideoUploadForm = () => {
         throw new Error('Could not get public URL for the uploaded video.');
       }
 
-      const success = await updateSetting('heroVideoUrl', publicUrlData.publicUrl, 'homepage');
+      const success = await updateSetting('homepage_hero_video_url', publicUrlData.publicUrl, 'homepage');
 
       if (success) {
         toast.success('Hero video uploaded and setting updated successfully!');

--- a/src/components/dashboard/HeroSection.tsx
+++ b/src/components/dashboard/HeroSection.tsx
@@ -17,7 +17,7 @@ export default function HeroSection() {
 
   useEffect(() => {
     const fetchHeroVideo = async () => {
-      const url = await getSetting('heroVideoUrl');
+      const url = await getSetting('homepage_hero_video_url');
       if (url) {
         setHeroVideoUrl(url);
       }

--- a/src/utils/settingsOperations.ts
+++ b/src/utils/settingsOperations.ts
@@ -16,7 +16,19 @@ export const getSetting = async (key: string): Promise<string | null> => {
       return null;
     }
 
-    return data ? (data as any).value : null;
+    const rawValue = data ? (data as any).value : null;
+
+    if (rawValue && typeof rawValue === 'string') {
+      try {
+        // The value might be a JSON string (e.g., "\"https://url.com\""), so parse it.
+        return JSON.parse(rawValue);
+      } catch (e) {
+        // If parsing fails, it's probably not a JSON string, so return it as is.
+        return rawValue;
+      }
+    }
+
+    return rawValue;
   } catch (error) {
     console.error(`Error in getSetting for ${key}:`, error);
     return null;


### PR DESCRIPTION
This commit addresses the hero video upload and display issue.

The initial problem was a missing `system_settings` table, which this commit resolves by adding a database migration to create it.

Additionally, it fixes a key mismatch where the video URL was being saved with one key and fetched with another. The code is now aligned to use 'homepage_hero_video_url' consistently.

Finally, the `getSetting` utility function is updated to correctly parse the video URL, which was being stored as a JSON-encoded string, ensuring a clean URL is passed to the frontend.