### PR TITLE
fix(admin): Increase z-index of date picker popover

### DIFF
--- a/src/components/admin/ContestManagement.tsx
+++ b/src/components/admin/ContestManagement.tsx
@@ -907,7 +907,7 @@ export const ContestManagement = () => {
                       )}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
+                  <PopoverContent className="w-auto p-0 z-[100]" align="start">
                     <Calendar
                       mode="single"
                       selected={contestForm.start_date || undefined}
@@ -936,7 +936,7 @@ export const ContestManagement = () => {
                       )}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
+                  <PopoverContent className="w-auto p-0 z-[100]" align="start">
                     <Calendar
                       mode="single"
                       selected={contestForm.end_date || undefined}
@@ -1083,7 +1083,7 @@ export const ContestManagement = () => {
                       )}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
+                  <PopoverContent className="w-auto p-0 z-[100]" align="start">
                     <Calendar
                       mode="single"
                       selected={contestForm.start_date || undefined}
@@ -1112,7 +1112,7 @@ export const ContestManagement = () => {
                       )}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
+                  <PopoverContent className="w-auto p-0 z-[100]" align="start">
                     <Calendar
                       mode="single"
                       selected={contestForm.end_date || undefined}


### PR DESCRIPTION
The date picker popover in the contest creation and edit forms was not clickable because it was being rendered underneath the dialog's overlay. Both components had a z-index of 50.

This change increases the z-index of the PopoverContent for the date pickers to 100, ensuring it appears on top of the dialog overlay and is interactive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Date picker popovers in Create New Contest and Edit Contest dialogs now consistently appear above other interface elements, preventing calendars from being obscured or unclickable.
  - Ensures reliable start/end date selection across admin contest management, with consistent stacking behavior across browsers and screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->