### PR TITLE
fix(admin): Correct PopoverTrigger composition for date picker

### DIFF
--- a/src/components/admin/ContestManagement.tsx
+++ b/src/components/admin/ContestManagement.tsx
@@ -891,7 +891,7 @@ export const ContestManagement = () => {
               <div>
                 <Label>Start Date *</Label>
                 <Popover>
-                  <PopoverTrigger asChild>
+                  <PopoverTrigger>
                     <Button
                       variant="outline"
                       className={cn(
@@ -920,7 +920,7 @@ export const ContestManagement = () => {
               <div>
                 <Label>End Date *</Label>
                 <Popover>
-                  <PopoverTrigger asChild>
+                  <PopoverTrigger>
                     <Button
                       variant="outline"
                       className={cn(
@@ -1067,7 +1067,7 @@ export const ContestManagement = () => {
               <div>
                 <Label>Start Date *</Label>
                 <Popover>
-                  <PopoverTrigger asChild>
+                  <PopoverTrigger>
                     <Button
                       variant="outline"
                       className={cn(
@@ -1096,7 +1096,7 @@ export const ContestManagement = () => {
               <div>
                 <Label>End Date *</Label>
                 <Popover>
-                  <PopoverTrigger asChild>
+                  <PopoverTrigger>
                     <Button
                       variant="outline"
                       className={cn(


### PR DESCRIPTION
The date picker was not opening because of an issue with the PopoverTrigger. The `asChild` prop was causing a conflict that prevented the trigger from firing correctly.

This change removes the `asChild` prop and nests the Button component directly inside the PopoverTrigger. This ensures that the click events are handled correctly and the popover with the calendar opens as expected.