### PR TITLE
Fix: Remove scrolling from create song card

### DIFF
--- a/src/components/music-generation/MusicGenerationWorkflow.tsx
+++ b/src/components/music-generation/MusicGenerationWorkflow.tsx
@@ -168,47 +168,42 @@ export const MusicGenerationWorkflow = ({ preSelectedGenre, initialPrompt, templ
     (selectedGenreId ? genres.find(g => g.id === selectedGenreId)?.name : "");
 
   return (
-    <div className="space-y-6">
-      {/* Mode Tabs */}
-      <div className="flex justify-center">
-        <div className="flex bg-muted rounded-lg p-1">
-          <button
-            onClick={() => setCreationMode('prompt')}
-            className={`px-6 py-2 rounded-md text-sm font-medium transition-colors ${
-              creationMode === 'prompt' 
-                ? 'bg-background text-foreground shadow-sm' 
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Simple
-          </button>
-          <button
-            onClick={() => setCreationMode('lyrics')}
-            className={`px-6 py-2 rounded-md text-sm font-medium transition-colors ${
-              creationMode === 'lyrics' 
-                ? 'bg-background text-foreground shadow-sm' 
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Custom
-          </button>
+    <Card className="bg-white/5 border-white/10 backdrop-blur-sm">
+      <CardHeader>
+        <CardTitle className="text-2xl font-bold">
+          {templateData ? `Template: ${templateData.template_name}` : "Create a new song"}
+        </CardTitle>
+        <CardDescription>
+          {templateData ? `Genre: ${templateData.genres?.name}` : "Describe your song or provide lyrics"}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Mode Tabs */}
+        <div className="flex justify-center">
+          <div className="flex bg-muted rounded-lg p-1">
+            <button
+              onClick={() => setCreationMode('prompt')}
+              className={`px-6 py-2 rounded-md text-sm font-medium transition-colors ${
+                creationMode === 'prompt'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Simple
+            </button>
+            <button
+              onClick={() => setCreationMode('lyrics')}
+              className={`px-6 py-2 rounded-md text-sm font-medium transition-colors ${
+                creationMode === 'lyrics'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Custom
+            </button>
+          </div>
         </div>
-      </div>
 
-      {/* Template Info */}
-      {templateData && (
-        <div className="text-center">
-          <h3 className="text-lg font-bold">Using Template: {templateData.template_name}</h3>
-          <p className="text-muted-foreground">
-            Genre: {templateData.genres?.name}
-          </p>
-        </div>
-      )}
-
-      {/* Main Heading */}
-      <div>
-        <h2 className="text-2xl font-bold mb-6">Describe your song</h2>
-        
         {/* Song Description/Lyrics Input */}
         <div className="space-y-2 mb-4">
           <Label htmlFor="prompt-input" className="text-sm font-medium">
@@ -224,7 +219,7 @@ export const MusicGenerationWorkflow = ({ preSelectedGenre, initialPrompt, templ
             placeholder={creationMode === 'prompt' ? "e.g., A vibrant Afrobeat track celebrating the joy of life" : "Paste your full lyrics here..."}
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
-            className="min-h-[100px] resize-none"
+            className="resize-none"
             maxLength={creationMode === 'prompt' ? 99 : undefined}
           />
           {creationMode === 'prompt' && (
@@ -241,85 +236,87 @@ export const MusicGenerationWorkflow = ({ preSelectedGenre, initialPrompt, templ
           />
           <Label htmlFor="instrumental-switch">Instrumental</Label>
         </div>
-      </div>
 
-      {/* Custom Mode Fields */}
-      {creationMode === 'lyrics' && (
-        <div className="space-y-4">
-          <div>
-            <Label htmlFor="title" className="text-sm font-medium">Song Title <span className="text-red-500">*</span></Label>
-            <Input 
-              id="title" 
-              placeholder="e.g., Midnight Rain" 
-              value={title} 
-              onChange={(e) => setTitle(e.target.value)} 
-              className="mt-1"
-            />
-          </div>
-        </div>
-      )}
-
-      {/* Genre Selection for non-template mode */}
-      {!templateData && (
-        <div className="space-y-2">
-          <Label htmlFor="genre" className="text-sm font-medium">Genre <span className="text-red-500">*</span></Label>
-          {genresLoading ? (
-            <div className="flex items-center text-sm text-muted-foreground">
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> 
-              Loading genres...
+        {/* Custom Mode Fields */}
+        {creationMode === 'lyrics' && (
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="title" className="text-sm font-medium">Song Title <span className="text-red-500">*</span></Label>
+              <Input
+                id="title"
+                placeholder="e.g., Midnight Rain"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="mt-1"
+              />
             </div>
-          ) : (
-            <Select value={selectedGenreId} onValueChange={setSelectedGenreId} disabled={genresLoading}>
-              <SelectTrigger id="genre">
-                <SelectValue placeholder="Select a genre" />
-              </SelectTrigger>
-              <SelectContent>
-                {genres.map(genre => (
-                  <SelectItem key={genre.id} value={genre.id}>
-                    {genre.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-        </div>
-      )}
-
-      {/* AI Model Selection */}
-      <div className="space-y-2">
-        <Label htmlFor="model" className="text-sm font-medium">AI Model</Label>
-        <Select value={selectedModel} onValueChange={setSelectedModel}>
-          <SelectTrigger id="model">
-            <SelectValue placeholder="Select an AI model" />
-          </SelectTrigger>
-          <SelectContent>
-            {availableModels.map(model => (
-              <SelectItem key={model.value} value={model.value}>
-                {model.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      {/* Generate Button */}
-      <Button
-        onClick={handleGenerate}
-        disabled={isGenerating || genresLoading || (!selectedGenreId && !templateData)}
-        className="w-full bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 text-white font-bold text-lg py-6"
-        size="lg"
-      >
-        {isGenerating ? (
-          <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-        ) : (
-          <Music className="mr-2 h-5 w-5" />
+          </div>
         )}
-        Create (20 Credits)
-      </Button>
 
-      <p className="text-xs text-muted-foreground text-center">
-        Generation takes 1-2 minutes. Your song will appear in the Library.
-      </p>
-    </div>
+        {/* Genre Selection for non-template mode */}
+        {!templateData && (
+          <div className="space-y-2">
+            <Label htmlFor="genre" className="text-sm font-medium">Genre <span className="text-red-500">*</span></Label>
+            {genresLoading ? (
+              <div className="flex items-center text-sm text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading genres...
+              </div>
+            ) : (
+              <Select value={selectedGenreId} onValueChange={setSelectedGenreId} disabled={genresLoading}>
+                <SelectTrigger id="genre">
+                  <SelectValue placeholder="Select a genre" />
+                </SelectTrigger>
+                <SelectContent>
+                  {genres.map(genre => (
+                    <SelectItem key={genre.id} value={genre.id}>
+                      {genre.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+        )}
+
+        {/* AI Model Selection */}
+        <div className="space-y-2">
+          <Label htmlFor="model" className="text-sm font-medium">AI Model</Label>
+          <Select value={selectedModel} onValueChange={setSelectedModel}>
+            <SelectTrigger id="model">
+              <SelectValue placeholder="Select an AI model" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableModels.map(model => (
+                <SelectItem key={model.value} value={model.value}>
+                  {model.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardContent>
+
+      <div className="p-6 pt-0">
+        {/* Generate Button */}
+        <Button
+          onClick={handleGenerate}
+          disabled={isGenerating || genresLoading || (!selectedGenreId && !templateData)}
+          className="w-full bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 text-white font-bold"
+          size="lg"
+        >
+          {isGenerating ? (
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+          ) : (
+            <Music className="mr-2 h-5 w-5" />
+          )}
+          Create (20 Credits)
+        </Button>
+
+        <p className="text-xs text-muted-foreground text-center mt-4">
+          Generation takes 1-2 minutes. Your song will appear in the Library.
+        </p>
+      </div>
+    </Card>
   );
 };

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -45,11 +45,11 @@ const Create = () => {
   return (
     <ResizablePanelGroup
       direction="horizontal"
-      className="h-screen bg-zinc-900 text-white"
+      className="h-screen bg-black text-white"
     >
       {/* Left Panel: Create Song Form */}
       <ResizablePanel defaultSize={35}>
-        <div className="h-full p-4 bg-zinc-900 overflow-y-auto no-scrollbar">
+        <div className="h-full p-4 bg-black overflow-y-auto no-scrollbar">
           <MusicGenerationWorkflow
             preSelectedGenre={selectedGenre}
             initialPrompt={initialPrompt}
@@ -80,7 +80,7 @@ const Create = () => {
 
       {/* Right Panel: Lyrics Display */}
       <ResizablePanel defaultSize={15}>
-        <div className="h-full p-4 bg-zinc-950 overflow-y-auto no-scrollbar">
+        <div className="h-full p-4 bg-black overflow-y-auto no-scrollbar">
           {selectedSong ? (
             <div>
               <div className="flex items-center justify-between mb-4">


### PR DESCRIPTION
This commit removes the internal scrolling from the create song card. The card will now expand to fit its content, and the parent panel will scroll if the content overflows. This addresses the user's feedback about the card having a scrollbar and not taking up the full page length.