### PR TITLE
Fix: Refactor Create Page Layout and Card Scrolling

### DIFF
--- a/src/components/music-generation/MusicGenerationWorkflow.tsx
+++ b/src/components/music-generation/MusicGenerationWorkflow.tsx
@@ -168,7 +168,7 @@ export const MusicGenerationWorkflow = ({ preSelectedGenre, initialPrompt, templ
     (selectedGenreId ? genres.find(g => g.id === selectedGenreId)?.name : "");
 
   return (
-    <Card className="bg-white/5 border-white/10 backdrop-blur-sm h-full flex flex-col">
+    <Card className="bg-white/5 border-white/10 backdrop-blur-sm">
       <CardHeader>
         <CardTitle className="text-2xl font-bold">
           {templateData ? `Template: ${templateData.template_name}` : "Create a new song"}
@@ -177,7 +177,7 @@ export const MusicGenerationWorkflow = ({ preSelectedGenre, initialPrompt, templ
           {templateData ? `Genre: ${templateData.genres?.name}` : "Describe your song or provide lyrics"}
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-6 flex-grow overflow-y-auto no-scrollbar">
+      <CardContent className="space-y-4">
         {/* Mode Tabs */}
         <div className="flex justify-center">
           <div className="flex bg-muted rounded-lg p-1">

--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -44,62 +44,63 @@ const Create = () => {
 
   return (
     <ResizablePanelGroup
-      direction="horizontal"
+      direction="vertical"
       className="h-screen bg-black text-white"
     >
-      {/* Left Panel: Create Song Form */}
-      <ResizablePanel defaultSize={35}>
-        <div className="h-full p-4 bg-black overflow-y-auto no-scrollbar">
-          <MusicGenerationWorkflow
-            preSelectedGenre={selectedGenre}
-            initialPrompt={initialPrompt}
-          />
-        </div>
-      </ResizablePanel>
-      <ResizableHandle withHandle />
-
-      {/* Middle Panel: Song Library */}
       <ResizablePanel defaultSize={50}>
-        <div className="h-full p-4 bg-black overflow-y-auto no-scrollbar">
-          <div className="pb-4">
-              <h2 className="text-xl font-semibold text-white mb-4">My Workspace</h2>
-              <div className="relative">
-                <input
-                  type="text"
-                  placeholder="Search"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-2 text-sm text-white placeholder-zinc-500"
-                />
-              </div>
+        <div className="p-4 bg-black no-scrollbar">
+          <div className="max-w-4xl mx-auto">
+            <MusicGenerationWorkflow
+              preSelectedGenre={selectedGenre}
+              initialPrompt={initialPrompt}
+            />
           </div>
-          <SongLibrary onSongSelect={setSelectedSong} searchTerm={searchTerm} />
         </div>
       </ResizablePanel>
       <ResizableHandle withHandle />
-
-      {/* Right Panel: Lyrics Display */}
-      <ResizablePanel defaultSize={15}>
-        <div className="h-full p-4 bg-black overflow-y-auto no-scrollbar">
-          {selectedSong ? (
-            <div>
-              <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-lg font-semibold">Lyrics - {selectedSong.title}</h3>
-                  <button
+      <ResizablePanel defaultSize={50}>
+        <ResizablePanelGroup direction="horizontal">
+          <ResizablePanel defaultSize={75}>
+            <div className="h-full p-4 bg-black overflow-y-auto no-scrollbar">
+              <div className="pb-4">
+                <h2 className="text-xl font-semibold text-white mb-4">My Workspace</h2>
+                <div className="relative">
+                  <input
+                    type="text"
+                    placeholder="Search"
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-2 text-sm text-white placeholder-zinc-500"
+                  />
+                </div>
+              </div>
+              <SongLibrary onSongSelect={setSelectedSong} searchTerm={searchTerm} />
+            </div>
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={25}>
+            <div className="h-full p-4 bg-black overflow-y-auto no-scrollbar">
+              {selectedSong ? (
+                <div>
+                  <div className="flex items-center justify-between mb-4">
+                    <h3 className="text-lg font-semibold">Lyrics - {selectedSong.title}</h3>
+                    <button
                       onClick={() => setSelectedSong(null)}
                       className="text-zinc-500 hover:text-white"
-                  >
+                    >
                       &times;
-                  </button>
-              </div>
-              <LyricsDisplay lyrics={selectedSong?.lyrics || null} />
+                    </button>
+                  </div>
+                  <LyricsDisplay lyrics={selectedSong?.lyrics || null} />
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-full">
+                  <p className="text-zinc-500">Select a song to view lyrics.</p>
+                </div>
+              )}
             </div>
-          ) : (
-            <div className="flex items-center justify-center h-full">
-              <p className="text-zinc-500">Select a song to view lyrics.</p>
-            </div>
-          )}
-        </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
       </ResizablePanel>
     </ResizablePanelGroup>
   );


### PR DESCRIPTION
This commit addresses two UI issues on the Create page:

1. The "create song" display card was scrollable. This has been fixed by removing the `h-full` and `overflow-y-auto` classes from the card and its container, allowing it to size to its content. The internal spacing has also been made more compact.

2. The Create page was in a container that did not use the full width of the page. This has been fixed by changing the layout from a horizontal `ResizablePanelGroup` to a vertical one. The music generation form is now in the top panel, spanning the full width, and the song library and lyrics viewer are in a nested horizontal panel group below. This retains all functionality while addressing the user's layout feedback.