### PR TITLE
Fix: Adjust create song card styling and page height

### DIFF
--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -45,7 +45,7 @@ const Create = () => {
   return (
     <ResizablePanelGroup
       direction="horizontal"
-      className="h-screen bg-black text-white"
+      className="h-full bg-black text-white"
     >
       {/* Left Panel: Create Song Form */}
       <ResizablePanel defaultSize={35}>


### PR DESCRIPTION
This commit addresses two UI issues on the Create page:

1.  The create song display card is no longer scrollable. The spacing between elements has been reduced to ensure all content fits within the card's bounds. This was done by modifying `MusicGenerationWorkflow.tsx`.

2.  The Create page now correctly fills the available vertical space. The `h-screen` class was replaced with `h-full` in `Create.tsx` to prevent the page from overflowing its container.

Additionally, minor linting issues in `MusicGenerationWorkflow.tsx` were fixed.