### PR TITLE
fix(create): Ensure create page content fills available height

### DIFF
--- a/src/pages/Create.tsx
+++ b/src/pages/Create.tsx
@@ -45,7 +45,7 @@ const Create = () => {
   return (
     <ResizablePanelGroup
       direction="horizontal"
-      className="h-full bg-black text-white"
+      className="flex-1 bg-black text-white"
     >
       {/* Left Panel: Create Song Form */}
       <ResizablePanel defaultSize={35}>


### PR DESCRIPTION
The content on the create page was not taking up the full available height because its root container used `h-full`. The parent `main` element has a `padding-bottom` to avoid being overlapped by the fixed audio player. This combination caused the content to be squished.

This change replaces `h-full` with `flex-1` on the `ResizablePanelGroup` in `Create.tsx`. Since the parent `main` element is a `flex flex-col` container, `flex-1` correctly instructs the panel group to expand and fill the available content area, respecting the parent's padding.