### PR TITLE
refactor(layout): Integrate AudioPlayer into document flow

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -56,7 +56,7 @@ export const AudioPlayer = () => {
 
   return (
     <div 
-      className="fixed bottom-0 left-0 right-0 bg-black/50 backdrop-blur-md text-white p-3 border-t border-white/10 shadow-lg z-40"
+      className="bottom-0 left-0 right-0 bg-black/50 backdrop-blur-md text-white p-3 border-t border-white/10 shadow-lg z-40"
     >
       <div className="flex items-center gap-4 max-w-screen-2xl mx-auto">
         

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -26,7 +26,7 @@ const AppLayoutContent = () => {
         <div className="hidden md:block flex-shrink-0 w-48">
           <Sidebar className="bg-black border-r border-white/10" />
         </div>
-        <main className="flex-1 flex flex-col overflow-y-auto" style={{ paddingBottom: '120px' }}>
+        <main className="flex-1 flex flex-col overflow-y-auto">
           <Outlet />
         </main>
       </div>


### PR DESCRIPTION
The Create page content did not fill the full available height due to a `padding-bottom` on the main content area. This padding was a workaround to prevent a `fixed` position AudioPlayer from overlapping the content.

This refactor removes the `fixed` positioning from the AudioPlayer and removes the corresponding `padding-bottom` from the main layout. The AudioPlayer is now part of the standard flexbox layout, allowing the main content to naturally fill the space above it. This resolves the height issue on the Create page and improves the overall layout structure.