### PR TITLE
feat: Update color scheme to use gradient

### DIFF
--- a/src/components/music-generation/MusicGenerationWorkflow.tsx
+++ b/src/components/music-generation/MusicGenerationWorkflow.tsx
@@ -310,7 +310,8 @@ export const MusicGenerationWorkflow = ({ preSelectedGenre, initialPrompt, templ
         <Button
           onClick={handleGenerate}
           disabled={isGenerating || genresLoading || (!selectedGenreId && !templateData)}
-          className="w-full bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 text-white font-bold"
+          className="w-full"
+          variant="primary"
         >
           {isGenerating ? (
             <Loader2 className="mr-2 h-5 w-5 animate-spin" />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,11 +10,12 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+        default: "btn-outline-primary bg-background hover:bg-accent hover:text-accent-foreground",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "btn-outline-primary bg-background hover:bg-accent hover:text-accent-foreground",
+        primary: "bg-gradient-to-r from-pink-500 to-orange-500 text-white font-bold hover:from-pink-600 hover:to-orange-600",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/src/index.css
+++ b/src/index.css
@@ -23,7 +23,9 @@
     --card-foreground: 210 40% 98%;
     --popover: 0 0% 0%;
     --popover-foreground: 210 40% 98%;
-    --primary: 262.1 83.3% 57.8%;
+    --primary: 341 83% 52%;
+    --primary-gradient-from: #e91e63;
+    --primary-gradient-to: #ff9800;
     --primary-foreground: 210 40% 98%;
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
@@ -35,9 +37,9 @@
     --destructive-foreground: 210 40% 98%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
-    --ring: 262.1 83.3% 57.8%;
+    --ring: 341 83% 52%;
     --radius: 1.5rem;
-    --chart-1: 262.1 83.3% 57.8%;
+    --chart-1: 341 83% 52%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
@@ -107,5 +109,24 @@
     -webkit-text-fill-color: white !important;
     caret-color: white !important;
     transition: background-color 5000s ease-in-out 0s;
+  }
+  .btn-outline-primary {
+    border: 2px solid transparent;
+    background-clip: padding-box;
+    position: relative;
+  }
+  .btn-outline-primary::before {
+    content: '';
+    position: absolute;
+    top: 0; right: 0; bottom: 0; left: 0;
+    z-index: -1;
+    margin: -2px;
+    border-radius: inherit;
+    background: linear-gradient(to right, var(--primary-gradient-from), var(--primary-gradient-to));
+  }
+  .text-gradient-primary {
+    background: linear-gradient(to right, var(--primary-gradient-from), var(--primary-gradient-to));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
   }
 }


### PR DESCRIPTION
This commit updates the application's color scheme to use a pink-to-orange gradient.

- The primary color is changed from purple to pink.
- A new `primary` button variant is introduced with a solid gradient background.
- The `default` and `outline` button variants now have a gradient outline.
- A new `.text-gradient-primary` utility class is added for gradient text.