### PR TITLE
Fix: Ensure genre template edits are reflected

### DIFF
--- a/src/hooks/use-genre-templates.ts
+++ b/src/hooks/use-genre-templates.ts
@@ -76,7 +76,7 @@ export const useGenreTemplates = () => {
     try {
       const { error } = await supabase
         .from('genre_templates')
-        .update(templateData)
+        .update({ ...templateData, updated_at: new Date().toISOString() })
         .eq('id', id);
 
       if (error) throw error;


### PR DESCRIPTION
When an admin edits a genre template, the changes were not being reflected in the UI. This was likely due to the `updated_at` timestamp not being explicitly updated in the database, which could cause caching issues or prevent real-time updates from being triggered.

This commit modifies the `updateTemplate` function in the `useGenreTemplates` hook to include the current timestamp in the update payload. This ensures that the record's modification time is always correctly updated, which should resolve the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * “Last updated” timestamps for genre templates now refresh immediately after edits, ensuring accurate display across the app.
  * Improves sorting by recency and consistency in views that rely on update times (e.g., lists, recent changes).
  * Enhances reliability of visual cues and notifications related to template updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->