### PR TITLE
feat: Implement contest rules visibility and terms and conditions page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import Support from "./pages/Support";
 import Admin from "./pages/Admin";
 import AffiliatePage from "./pages/Affiliate";
 import WinnerStatus from "./pages/WinnerStatus";
+import Terms from "./pages/Terms";
 
 // Layouts
 import AppLayout from "./layouts/AppLayout";
@@ -51,6 +52,7 @@ const App = () => {
                 
                 <Route path="/login" element={<Login />} />
                 <Route path="/register" element={<Register />} />
+                <Route path="/terms" element={<Terms />} />
                 <Route element={<AuthLayout />}>
                   <Route path="/register/admin" element={<AdminRegister />} />
                 </Route>

--- a/src/components/admin/ContentManagement.tsx
+++ b/src/components/admin/ContentManagement.tsx
@@ -1,387 +1,109 @@
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "sonner";
-import { CheckCircle, XCircle, Pencil, Trash, Eye } from "lucide-react";
-
-const mockContentItems = [
-  { 
-    id: 1, 
-    title: "Welcome to MelodyVerse", 
-    type: "article", 
-    status: "published", 
-    author: "Admin", 
-    created: "2025-03-15" 
-  },
-  { 
-    id: 2, 
-    title: "How to Create Your First Song", 
-    type: "tutorial", 
-    status: "published", 
-    author: "Admin", 
-    created: "2025-03-18" 
-  },
-  { 
-    id: 3, 
-    title: "Voice Cloning Guide", 
-    type: "guide", 
-    status: "draft", 
-    author: "Admin", 
-    created: "2025-03-25" 
-  },
-  { 
-    id: 4, 
-    title: "Latest Platform Updates", 
-    type: "announcement", 
-    status: "draft", 
-    author: "Admin", 
-    created: "2025-04-10" 
-  },
-];
+import { supabase } from "@/integrations/supabase/client";
+import { Loader2 } from "lucide-react";
 
 export const ContentManagement = () => {
-  const [isAddOpen, setIsAddOpen] = useState(false);
-  const [isEditOpen, setIsEditOpen] = useState(false);
-  const [isViewOpen, setIsViewOpen] = useState(false);
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState("all");
-  const [selectedItem, setSelectedItem] = useState<any>(null);
-  const [contentItems, setContentItems] = useState(mockContentItems);
+  const [activeTab, setActiveTab] = useState("terms");
+  const [terms, setTerms] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
 
-  const handleAddContent = () => {
-    setIsAddOpen(true);
-  };
+  useEffect(() => {
+    if (activeTab === "terms") {
+      fetchTerms();
+    }
+  }, [activeTab]);
 
-  const handleEditContent = (item: any) => {
-    setSelectedItem(item);
-    setIsEditOpen(true);
-  };
+  const fetchTerms = async () => {
+    setLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from("system_settings")
+        .select("value")
+        .eq("key", "terms_and_conditions")
+        .single();
 
-  const handleViewContent = (item: any) => {
-    setSelectedItem(item);
-    setIsViewOpen(true);
-  };
-  
-  const handleDeleteContent = (item: any) => {
-    setSelectedItem(item);
-    setIsDeleteOpen(true);
-  };
-
-  const handlePublish = (id: number) => {
-    setContentItems(
-      contentItems.map(item => 
-        item.id === id 
-          ? { ...item, status: "published" } 
-          : item
-      )
-    );
-    
-    toast.success("Content published successfully");
-  };
-
-  const handleUnpublish = (id: number) => {
-    setContentItems(
-      contentItems.map(item => 
-        item.id === id 
-          ? { ...item, status: "draft" } 
-          : item
-      )
-    );
-    
-    toast.success("Content unpublished");
-  };
-
-  const confirmDelete = () => {
-    if (selectedItem) {
-      setContentItems(contentItems.filter(item => item.id !== selectedItem.id));
-      setIsDeleteOpen(false);
-      toast.success("Content deleted successfully");
+      if (error && error.code !== 'PGRST116') { // Ignore 'exact one row' error if not found
+        throw error;
+      }
+      if (data) {
+        setTerms(data.value || "");
+      }
+    } catch (error: any) {
+      toast.error("Failed to fetch terms: " + error.message);
+    } finally {
+      setLoading(false);
     }
   };
-  
-  const filteredItems = contentItems.filter(item => {
-    if (activeTab === "all") return true;
-    if (activeTab === "published") return item.status === "published";
-    if (activeTab === "draft") return item.status === "draft";
-    return true;
-  });
+
+  const handleSaveTerms = async () => {
+    setSaving(true);
+    try {
+      const { error } = await supabase
+        .from("system_settings")
+        .upsert({ key: "terms_and_conditions", value: terms }, { onConflict: 'key' });
+
+      if (error) {
+        throw error;
+      }
+      toast.success("Terms and Conditions updated successfully");
+    } catch (error: any) {
+      toast.error("Failed to save terms: " + error.message);
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
-    <div>
-      <div className="flex justify-between mb-6">
-        <h2 className="text-2xl font-bold">Content Management</h2>
-        <Button onClick={handleAddContent}>Add New Content</Button>
-      </div>
-      
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold">Content Management</h2>
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
-          <TabsTrigger value="all">All Content</TabsTrigger>
-          <TabsTrigger value="published">Published</TabsTrigger>
-          <TabsTrigger value="draft">Drafts</TabsTrigger>
+          <TabsTrigger value="terms">Terms and Conditions</TabsTrigger>
+          {/* Add other site content tabs here if needed */}
         </TabsList>
         
-        <TabsContent value={activeTab} className="mt-6">
+        <TabsContent value="terms" className="mt-6">
           <Card>
             <CardHeader>
-              <div className="text-sm text-muted-foreground">
-                {filteredItems.length} items
-              </div>
+              <CardTitle>Edit Terms and Conditions</CardTitle>
             </CardHeader>
             <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Title</TableHead>
-                    <TableHead>Type</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Author</TableHead>
-                    <TableHead>Created</TableHead>
-                    <TableHead>Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredItems.map((item) => (
-                    <TableRow key={item.id}>
-                      <TableCell className="font-medium">{item.title}</TableCell>
-                      <TableCell className="capitalize">{item.type}</TableCell>
-                      <TableCell>
-                        <span className={`px-2 py-1 rounded-full text-xs ${
-                          item.status === "published" ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800"
-                        }`}>
-                          {item.status}
-                        </span>
-                      </TableCell>
-                      <TableCell>{item.author}</TableCell>
-                      <TableCell>{item.created}</TableCell>
-                      <TableCell>
-                        <div className="flex space-x-2">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleViewContent(item)}
-                          >
-                            <Eye className="h-4 w-4" />
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleEditContent(item)}
-                          >
-                            <Pencil className="h-4 w-4" />
-                          </Button>
-                          {item.status === "draft" ? (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => handlePublish(item.id)}
-                            >
-                              <CheckCircle className="h-4 w-4" />
-                            </Button>
-                          ) : (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => handleUnpublish(item.id)}
-                            >
-                              <XCircle className="h-4 w-4" />
-                            </Button>
-                          )}
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleDeleteContent(item)}
-                          >
-                            <Trash className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              {loading ? (
+                <div className="flex justify-center items-center h-64">
+                  <Loader2 className="h-8 w-8 animate-spin" />
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  <div>
+                    <Label htmlFor="terms-editor">Content (Markdown supported)</Label>
+                    <Textarea
+                      id="terms-editor"
+                      value={terms}
+                      onChange={(e) => setTerms(e.target.value)}
+                      className="min-h-[400px] font-mono"
+                      placeholder="Enter your terms and conditions here..."
+                    />
+                  </div>
+                  <div className="flex justify-end">
+                    <Button onClick={handleSaveTerms} disabled={saving}>
+                      {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                      Save Changes
+                    </Button>
+                  </div>
+                </div>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
       </Tabs>
-      
-      {/* Add Content Dialog */}
-      <Dialog open={isAddOpen} onOpenChange={setIsAddOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Add New Content</DialogTitle>
-            <DialogDescription>
-              Create a new content item for your platform
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div>
-              <label className="text-sm font-medium">Title</label>
-              <Input placeholder="Enter content title" className="mt-1" />
-            </div>
-            <div>
-              <label className="text-sm font-medium">Type</label>
-              <select className="w-full mt-1 border rounded-md p-2">
-                <option value="article">Article</option>
-                <option value="tutorial">Tutorial</option>
-                <option value="guide">Guide</option>
-                <option value="announcement">Announcement</option>
-              </select>
-            </div>
-            <div>
-              <label className="text-sm font-medium">Content</label>
-              <textarea
-                className="w-full mt-1 border rounded-md p-2 h-32"
-                placeholder="Write your content here..."
-              ></textarea>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsAddOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button onClick={() => {
-              setIsAddOpen(false);
-              toast.success("Content created as draft");
-            }}>
-              Save as Draft
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      
-      {/* Edit Content Dialog */}
-      <Dialog open={isEditOpen} onOpenChange={setIsEditOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Content</DialogTitle>
-            <DialogDescription>
-              Make changes to the selected content item
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div>
-              <label className="text-sm font-medium">Title</label>
-              <Input
-                defaultValue={selectedItem?.title}
-                className="mt-1"
-              />
-            </div>
-            <div>
-              <label className="text-sm font-medium">Type</label>
-              <select
-                className="w-full mt-1 border rounded-md p-2"
-                defaultValue={selectedItem?.type}
-              >
-                <option value="article">Article</option>
-                <option value="tutorial">Tutorial</option>
-                <option value="guide">Guide</option>
-                <option value="announcement">Announcement</option>
-              </select>
-            </div>
-            <div>
-              <label className="text-sm font-medium">Content</label>
-              <textarea
-                className="w-full mt-1 border rounded-md p-2 h-32"
-                defaultValue="This is the content of the selected item..."
-              ></textarea>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsEditOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button onClick={() => {
-              setIsEditOpen(false);
-              toast.success("Content updated successfully");
-            }}>
-              Save Changes
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      
-      {/* View Content Dialog */}
-      <Dialog open={isViewOpen} onOpenChange={setIsViewOpen}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>{selectedItem?.title}</DialogTitle>
-            <div className="flex items-center gap-2 mt-1">
-              <span className={`px-2 py-1 rounded-full text-xs ${
-                selectedItem?.status === "published" ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800"
-              }`}>
-                {selectedItem?.status}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                {selectedItem?.type} • {selectedItem?.created} • {selectedItem?.author}
-              </span>
-            </div>
-          </DialogHeader>
-          <div className="py-4">
-            <div className="prose max-w-none">
-              <p>This is the content of the "{selectedItem?.title}" article.</p>
-              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.</p>
-              <p>Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.</p>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button onClick={() => setIsViewOpen(false)}>
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      
-      {/* Delete Content Dialog */}
-      <Dialog open={isDeleteOpen} onOpenChange={setIsDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Content</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete "{selectedItem?.title}"?
-              This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsDeleteOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={confirmDelete}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 };

--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -8,6 +8,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "../components/ui/input";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Trophy, Calendar, Upload, Vote, Play, Pause } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/integrations/supabase/client";
@@ -409,27 +410,43 @@ const PastContestCard = ({ contest }: { contest: ContestType }) => {
             ) : (
               <div className="space-y-3">
                 {activeContests.map((contest) => (
-                  <div key={contest.id} className="flex items-center p-3 rounded-lg bg-white/5 hover:bg-white/10 transition-colors">
-                    <div className="flex-grow mx-4 min-w-0">
-                      <p className="font-semibold truncate text-white">{contest.title}</p>
-                      <p className="text-sm text-gray-400 line-clamp-1">{contest.description}</p>
-                      <div className="flex items-center gap-4 mt-1 text-xs text-gray-400">
-                        <div className="flex items-center gap-1"><Trophy className="h-4 w-4 text-dark-purple" /><span>Prize: {contest.prize}</span></div>
-                        <div className="flex items-center gap-1"><Calendar className="h-4 w-4" /><span>Ends: {new Date(contest.end_date).toLocaleDateString()}</span></div>
+                  <Card key={contest.id} className="bg-white/5 border-white/10">
+                    <CardContent className="p-4">
+                      <div className="flex items-center">
+                        <div className="flex-grow mx-4 min-w-0">
+                          <p className="font-semibold truncate text-white">{contest.title}</p>
+                          <p className="text-sm text-gray-400 line-clamp-1">{contest.description}</p>
+                          <div className="flex items-center gap-4 mt-1 text-xs text-gray-400">
+                            <div className="flex items-center gap-1"><Trophy className="h-4 w-4 text-dark-purple" /><span>Prize: {contest.prize}</span></div>
+                            <div className="flex items-center gap-1"><Calendar className="h-4 w-4" /><span>Ends: {new Date(contest.end_date).toLocaleDateString()}</span></div>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-4">
+                          {contest.is_unlocked ? (
+                            <Button size="sm" className="bg-dark-purple hover:bg-opacity-90 font-bold" onClick={() => openSubmissionDialog(contest)}>
+                              Submit Entry
+                            </Button>
+                          ) : (
+                            <Button size="sm" onClick={() => handleUnlockContest(contest)} disabled={submitting || (user?.credits ?? 0) < contest.entry_fee}>
+                              {submitting ? 'Unlocking...' : `Unlock for ${contest.entry_fee} credits`}
+                            </Button>
+                          )}
+                        </div>
                       </div>
-                    </div>
-                    <div className="flex items-center gap-4">
-                      {contest.is_unlocked ? (
-                        <Button size="sm" className="bg-dark-purple hover:bg-opacity-90 font-bold" onClick={() => openSubmissionDialog(contest)}>
-                          Submit Entry
-                        </Button>
-                      ) : (
-                        <Button size="sm" onClick={() => handleUnlockContest(contest)} disabled={submitting || (user?.credits ?? 0) < contest.entry_fee}>
-                          {submitting ? 'Unlocking...' : `Unlock for ${contest.entry_fee} credits`}
-                        </Button>
+                      {contest.rules && (
+                        <Accordion type="single" collapsible className="w-full mt-4">
+                          <AccordionItem value="item-1">
+                            <AccordionTrigger>View Rules</AccordionTrigger>
+                            <AccordionContent>
+                              <div className="prose prose-sm prose-invert max-w-none">
+                                <p>{contest.rules}</p>
+                              </div>
+                            </AccordionContent>
+                          </AccordionItem>
+                        </Accordion>
                       )}
-                    </div>
-                  </div>
+                    </CardContent>
+                  </Card>
                 ))}
               </div>
             )}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAuth } from "@/contexts/AuthContext";
@@ -16,6 +17,7 @@ const Register = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [agreeToTerms, setAgreeToTerms] = useState(false);
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   
@@ -146,10 +148,22 @@ const Register = () => {
               className="bg-black/20 border-white/20 text-white placeholder-gray-500"
             />
           </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox id="terms" checked={agreeToTerms} onCheckedChange={(checked) => setAgreeToTerms(checked as boolean)} />
+            <label
+              htmlFor="terms"
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-gray-400"
+            >
+              I agree to the{" "}
+              <Link to="/terms" target="_blank" className="text-dark-purple hover:underline">
+                Terms and Conditions
+              </Link>
+            </label>
+          </div>
           <Button
             type="submit"
             className="w-full bg-deep-purple font-bold"
-            disabled={loading}
+            disabled={loading || !agreeToTerms}
           >
             {loading ? "Creating account..." : "Sign Up"}
           </Button>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import ReactMarkdown from 'react-markdown';
+
+const Terms = () => {
+  const [terms, setTerms] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchTerms = async () => {
+      try {
+        const { data, error } = await supabase
+          .from('system_settings')
+          .select('value')
+          .eq('key', 'terms_and_conditions')
+          .single();
+
+        if (error) throw error;
+
+        if (data) {
+          setTerms(data.value || '');
+        }
+      } catch (error: any) {
+        console.error('Error fetching terms and conditions:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTerms();
+  }, []);
+
+  return (
+    <div className="p-4 md:p-8 text-white">
+      <Card className="bg-white/5 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-2xl">Terms and Conditions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex justify-center items-center h-64">
+              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
+              <span className="ml-2">Loading...</span>
+            </div>
+          ) : (
+            <div className="prose prose-invert max-w-none">
+              <ReactMarkdown>{terms}</ReactMarkdown>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Terms;

--- a/supabase/migrations/20250913192400_add_terms_and_conditions_setting.sql
+++ b/supabase/migrations/20250913192400_add_terms_and_conditions_setting.sql
@@ -1,0 +1,8 @@
+INSERT INTO public.system_settings (key, value, description, category)
+VALUES (
+    'terms_and_conditions',
+    '# Terms and Conditions\n\nPlease read these terms and conditions carefully before using Our Service.\n\nThis is a placeholder for the terms and conditions. Please edit this from the admin panel.',
+    'The terms and conditions for using the service.',
+    'content'
+)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
This commit introduces two new features:

1.  **Contest Rules Visibility:**
    -   The `Contest.tsx` page now displays the rules for active contests in a collapsible accordion.
    -   This makes the rules easily accessible to users viewing the contest.

2.  **Terms and Conditions Page:**
    -   A new "Terms and Conditions" page has been created at `/terms`.
    -   The content of this page is fetched from the `system_settings` table in the database, making it editable by an admin.
    -   The registration page (`Register.tsx`) now includes a mandatory checkbox to agree to the terms and conditions before signing up.
    -   The admin "Content Management" page has been updated to allow an administrator to edit the terms and conditions.