### PR TITLE
feat: Display contest rules and add terms and conditions page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,13 +33,7 @@ import AdminLayout from "./layouts/AdminLayout";
 // Protected Routes
 import ProtectedRoute from "./components/ProtectedRoute";
 
-import { ensureStorageBuckets } from './utils/storageSetup';
-
 const App = () => {
-  useEffect(() => {
-    ensureStorageBuckets();
-  }, []);
-  
   return (
     <ErrorBoundary>
       <BrowserRouter>

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -2,13 +2,18 @@
 import { Outlet } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Sidebar from "@/components/Sidebar";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { AudioPlayerProvider } from "@/contexts/AudioPlayerContext";
+import { ensureStorageBuckets } from "@/utils/storageSetup";
 import { AudioPlayer } from "@/components/AudioPlayer";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 
 const AppLayoutContent = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    ensureStorageBuckets();
+  }, []);
 
   return (
     <div className="h-screen flex flex-col overflow-hidden bg-black text-white font-sans">


### PR DESCRIPTION
This commit introduces two new features:
1.  The contest page now displays the rules for each contest. A "View Rules" button is available to toggle the visibility of the rules.
2.  A Terms and Conditions page has been added. It is accessible at `/terms` and linked from the registration page. Users must now agree to the terms before they can register. The content of the Terms and Conditions page is editable by an admin in the "Content Management" section of the admin panel.

This commit also includes a database migration to create the `terms_and_conditions` table.

This version also fixes a bug where the `ensureStorageBuckets` function was called for unauthenticated users, causing a storage API error. The function is now called only for authenticated users.