### PR TITLE
feat: Add admin-driven setup for Terms and Conditions

### DIFF
--- a/src/pages/TermsAndConditions.tsx
+++ b/src/pages/TermsAndConditions.tsx
@@ -1,11 +1,17 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/contexts/AuthContext';
+import { Link } from 'react-router-dom';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Terminal } from 'lucide-react';
 
 const TermsAndConditions = () => {
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [tableMissing, setTableMissing] = useState(false);
+  const { isAdmin } = useAuth();
 
   useEffect(() => {
     const fetchTerms = async () => {
@@ -16,7 +22,11 @@ const TermsAndConditions = () => {
           .single();
 
         if (error) {
-          throw error;
+          if (error.message.includes('relation "public.terms_and_conditions" does not exist')) {
+            setTableMissing(true);
+          } else {
+            throw error;
+          }
         }
 
         if (data) {
@@ -32,6 +42,46 @@ const TermsAndConditions = () => {
     fetchTerms();
   }, []);
 
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
+          <span className="ml-2">Loading...</span>
+        </div>
+      );
+    }
+
+    if (tableMissing) {
+      if (isAdmin()) {
+        return (
+          <Alert>
+            <Terminal className="h-4 w-4" />
+            <AlertTitle>Admin Notice: Setup Required</AlertTitle>
+            <AlertDescription>
+              The 'Terms and Conditions' page has not been set up yet. Please navigate to the{' '}
+              <Link to="/admin?tab=content&subtab=terms" className="font-semibold text-primary hover:underline">
+                Content Management
+              </Link>
+              {' '}section in the admin dashboard to create and publish the terms.
+            </AlertDescription>
+          </Alert>
+        );
+      }
+      return (
+        <div className="text-center py-10">
+          <p>The Terms and Conditions are not available at the moment. Please check back later.</p>
+        </div>
+      );
+    }
+
+    if (error) {
+      return <div className="text-red-500">{error}</div>;
+    }
+
+    return <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: content }} />;
+  };
+
   return (
     <div className="p-4 md:p-8 text-white">
       <Card className="bg-white/5 border-white/10">
@@ -39,16 +89,7 @@ const TermsAndConditions = () => {
           <CardTitle className="text-2xl font-semibold">Terms and Conditions</CardTitle>
         </CardHeader>
         <CardContent>
-          {loading ? (
-            <div className="flex justify-center items-center h-64">
-              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
-              <span className="ml-2">Loading...</span>
-            </div>
-          ) : error ? (
-            <div className="text-red-500">{error}</div>
-          ) : (
-            <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: content }} />
-          )}
+          {renderContent()}
         </CardContent>
       </Card>
     </div>

--- a/supabase/migrations/20250914063629_create_rpc_for_terms_table.sql
+++ b/supabase/migrations/20250914063629_create_rpc_for_terms_table.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION create_terms_and_conditions_table_and_seed()
+RETURNS void AS $$
+BEGIN
+    -- This function should be run by an admin.
+    -- The is_admin() function is expected to exist and handle authorization.
+    IF NOT public.is_admin(auth.uid()) THEN
+        RAISE EXCEPTION 'Only admins can perform this action';
+    END IF;
+
+    -- Create table if it doesn't exist
+    CREATE TABLE IF NOT EXISTS public.terms_and_conditions (
+        id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+        content TEXT,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    -- Create or replace the trigger function
+    -- This function is generic and can be reused for other tables.
+    CREATE OR REPLACE FUNCTION public.set_updated_at()
+    RETURNS TRIGGER AS $function$
+    BEGIN
+        NEW.updated_at = NOW();
+        RETURN NEW;
+    END;
+    $function$ LANGUAGE plpgsql;
+
+    -- Drop trigger if it exists on the target table, then create it
+    DROP TRIGGER IF EXISTS terms_and_conditions_updated_at ON public.terms_and_conditions;
+    CREATE TRIGGER terms_and_conditions_updated_at
+    BEFORE UPDATE ON public.terms_and_conditions
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_updated_at();
+
+    -- Enable RLS on the table
+    ALTER TABLE public.terms_and_conditions ENABLE ROW LEVEL SECURITY;
+
+    -- Drop existing policies if they exist to avoid errors on re-run, then create them
+    DROP POLICY IF EXISTS "Allow public read access" ON public.terms_and_conditions;
+    CREATE POLICY "Allow public read access" ON public.terms_and_conditions FOR SELECT USING (true);
+
+    DROP POLICY IF EXISTS "Allow admin write access" ON public.terms_and_conditions;
+    CREATE POLICY "Allow admin write access" ON public.terms_and_conditions FOR ALL USING (public.is_admin(auth.uid()));
+
+    -- Insert initial data only if the table is empty to prevent duplicates
+    IF NOT EXISTS (SELECT 1 FROM public.terms_and_conditions) THEN
+        INSERT INTO public.terms_and_conditions (content) VALUES ('# Terms and Conditions
+
+Please replace this with your actual terms and conditions.');
+    END IF;
+
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute permission on the function to the 'authenticated' role.
+-- The function itself contains the admin check, so this is safe.
+GRANT EXECUTE ON FUNCTION public.create_terms_and_conditions_table_and_seed() TO authenticated;


### PR DESCRIPTION
This commit fixes the error on the Terms and Conditions page which was caused by a missing 'terms_and_conditions' database table.

The solution includes:
- A new Supabase migration that creates an RPC function ('create_terms_and_conditions_table_and_seed') to safely create the table, RLS policies, and initial content from the client-side.
- An update to the admin Content Management page to allow an administrator to execute this function and set up the Terms and Conditions feature if it's not already initialized.
- An update to the public-facing Terms and Conditions page to display a graceful message when the content is not yet available, with a specific prompt for admins to complete the setup.