### PR TITLE
fix(contest): correct play button handler

### DIFF
--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -139,15 +139,15 @@ const Contest = () => {
     }
   };
 
-  const handlePlay = (song: any) => {
-    if (!song) return;
-    if (currentTrack?.id === song.id && isPlaying) {
+  const handlePlay = (entry: ContestEntry) => {
+    if (!entry) return;
+    if (currentTrack?.id === entry.id && isPlaying) {
       togglePlayPause();
-    } else if (song.audio_url) {
+    } else if (entry.video_url) {
       playTrack({
-        id: song.id,
-        title: song.title,
-        audio_url: song.audio_url
+        id: entry.id,
+        title: `Contest Entry by ${entry.profiles?.full_name || 'Unknown Artist'}`,
+        audio_url: entry.video_url,
       });
     }
   };


### PR DESCRIPTION
The play button on the contest entry page was not working because the `handlePlay` function was looking for an `audio_url` property on the entry object, but the object provides a `video_url`.

This commit updates the `handlePlay` function in `src/pages/Contest.tsx` to use the correct property (`video_url`) from the `ContestEntry` object. It also constructs a track title for the audio player, as one was not available on the entry object.

This resolves the issue by fixing the underlying logic without making unnecessary changes to the UI components.