### PR TITLE
fix(player): prevent proxying of contest entry audio

### DIFF
--- a/src/contexts/AudioPlayerContext.tsx
+++ b/src/contexts/AudioPlayerContext.tsx
@@ -193,10 +193,11 @@ export const AudioPlayerProvider = ({ children }: { children: ReactNode }) => {
         finalUrl = `${supabaseUrl}/functions/v1/suno-proxy?url=${encodeURIComponent(audioUrl)}`;
         console.log(`🎵 Using Suno proxy for URL: ${finalUrl}`);
       } else if (
-        audioUrl.startsWith('blob:') || 
-        audioUrl.startsWith('data:') || 
+        audioUrl.startsWith('blob:') ||
+        audioUrl.startsWith('data:') ||
         audioUrl.includes('storage.googleapis.com') ||
-        audioUrl.includes('apiboxfiles.erweima.ai')
+        audioUrl.includes('apiboxfiles.erweima.ai') ||
+        audioUrl.includes('bswfiynuvjvoaoyfdrso.supabase.co')
       ) {
         // Direct URLs that don't need proxy
         finalUrl = audioUrl;

--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -139,15 +139,15 @@ const Contest = () => {
     }
   };
 
-  const handlePlay = (song: any) => {
-    if (!song) return;
-    if (currentTrack?.id === song.id && isPlaying) {
+  const handlePlay = (entry: ContestEntry) => {
+    if (!entry) return;
+    if (currentTrack?.id === entry.id && isPlaying) {
       togglePlayPause();
-    } else if (song.audio_url) {
+    } else if (entry.video_url) {
       playTrack({
-        id: song.id,
-        title: song.title,
-        audio_url: song.audio_url
+        id: entry.id,
+        title: `Contest Entry by ${entry.profiles?.full_name || 'Unknown Artist'}`,
+        audio_url: entry.video_url,
       });
     }
   };


### PR DESCRIPTION
This commit resolves an issue where the play button for contest entries was not working. The root cause was twofold:

1. The audio player context was incorrectly proxying all `http` URLs, including those for user-uploaded contest entries from Supabase storage, through a service intended for Suno-generated audio. This caused playback to fail.
2. The `Contest.tsx` component was passing the wrong data to the audio player.

This commit addresses both issues:

- It updates `AudioPlayerContext.tsx` to add an exception for Supabase storage URLs, preventing them from being proxied and allowing for direct playback.
- It corrects the `handlePlay` function in `Contest.tsx` to use the `video_url` property from the contest entry and to construct a proper title for the track.

These changes ensure that contest entries can be played correctly.