### PR TITLE
fix: remove space before logo in navbar

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -18,7 +18,7 @@ const AppLayoutContent = () => {
           <Sidebar className="bg-black border-r border-white/10" />
         </div>
 
-        <div className="flex-1 flex flex-col">
+        <div className="flex-1 flex flex-col min-w-0">
           <Navbar onMenuClick={() => setSidebarOpen(true)} />
           <main className="flex-1 overflow-y-auto">
             <Outlet />


### PR DESCRIPTION
Adds `min-w-0` to the main content container to prevent the sidebar from pushing the navbar content.