### PR TITLE
Fix: Enable play button on contest entries

### DIFF
--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -139,15 +139,16 @@ const Contest = () => {
     }
   };
 
-  const handlePlay = (song: any) => {
-    if (!song) return;
-    if (currentTrack?.id === song.id && isPlaying) {
+  const handlePlay = (entry: ContestEntry) => {
+    if (!entry) return;
+    if (currentTrack?.id === entry.id && isPlaying) {
       togglePlayPause();
-    } else if (song.audio_url) {
+    } else if (entry.video_url) {
       playTrack({
-        id: song.id,
-        title: song.title,
-        audio_url: song.audio_url
+        id: entry.id,
+        title: entry.description || "Contest Entry",
+        audio_url: entry.video_url,
+        artist: entry.profiles?.full_name || 'Unknown Artist'
       });
     }
   };


### PR DESCRIPTION
The play button on the contest entries tab was not functional because it was not correctly passing the audio track information to the audio player.

This commit fixes the issue by updating the `handlePlay` function in `Contest.tsx`. The function now correctly maps the `ContestEntry` object to the `Track` object expected by the audio player. It uses the `video_url` from the contest entry as the `audio_url` for the track and sets the title and artist information appropriately.