### PR TITLE
fix: Correct auth flow for email links and password reset

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -200,6 +200,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       async (event, currentSession) => {
         if (!mounted) return;
 
+        // Do not handle password recovery here, let the ResetPassword page handle it
+        if (event === 'PASSWORD_RECOVERY') {
+            setLoading(false);
+            return;
+        }
+
         console.log(`AuthContext: Auth state change event: ${event}`, currentSession?.user?.id || 'No user');
 
         setSession(currentSession);


### PR DESCRIPTION
This commit addresses two issues with the authentication flow:

1.  **Dynamic Site URL for Emails:** Replaced hardcoded `window.location.origin` with a `VITE_SITE_URL` environment variable. This ensures that password reset and email verification links use the correct production URL instead of `localhost`.

2.  **Password Reset Flow:** Prevents automatic login after a user clicks the password reset link. The `AuthContext` now ignores the `PASSWORD_RECOVERY` event, allowing the `ResetPassword` page to be displayed correctly so the user can enter a new password.

- Updated `ForgotPassword.tsx`, `Register.tsx`, and `AuthContext.tsx` to use `import.meta.env.VITE_SITE_URL`.
- Added `.env.example` to instruct on configuring the site URL.
- Modified `AuthContext.tsx` to ignore the `PASSWORD_RECOVERY` event, preventing unwanted redirects.