### PR TITLE
fix(auth): redirect to reset password page during recovery flow

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -28,6 +28,9 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ allowedRoles, children 
   // If user is in password recovery mode, allow them to access any page
   // This is to ensure they can reach the /reset-password page.
   if (isPasswordRecovery) {
+    if (location.pathname !== '/reset-password') {
+      return <Navigate to="/reset-password" state={{ from: location }} replace />;
+    }
     return children ? <>{children}</> : <Outlet />;
   }
 


### PR DESCRIPTION
The ProtectedRoute component was not correctly handling the password recovery state, causing users to be redirected to the dashboard instead of the reset password page.

This change adds a check for the `isPasswordRecovery` state in `ProtectedRoute`. If the state is true, the user is redirected to the `/reset-password` page, unless they are already there.

This ensures the correct user flow for password recovery.