### PR TITLE
feat: Add custom email templates

### DIFF
--- a/supabase/auth/email/email_change.html
+++ b/supabase/auth/email/email_change.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Confirm Your Email Change</title>
+</head>
+<body>
+  <h2>Confirm Your Email Change</h2>
+  <p>You have requested to change the email address for your Afromelody account. Click the link below to confirm the change.</p>
+  <p>
+    <a href="{{ .ConfirmationURL }}">Confirm email change</a>
+  </p>
+</body>
+</html>

--- a/supabase/auth/email/invite.html
+++ b/supabase/auth/email/invite.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>You have been invited</title>
+</head>
+<body>
+  <h2>You have been invited</h2>
+  <p>You have been invited to join Afromelody. Click the link below to accept the invitation.</p>
+  <p>
+    <a href="{{ .ConfirmationURL }}">Accept invitation</a>
+  </p>
+</body>
+</html>

--- a/supabase/auth/email/magic_link.html
+++ b/supabase/auth/email/magic_link.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Your Magic Link</title>
+</head>
+<body>
+  <h2>Your Magic Link</h2>
+  <p>Click the link below to log in to Afromelody.</p>
+  <p>
+    <a href="{{ .ConfirmationURL }}">Log in</a>
+  </p>
+</body>
+</html>

--- a/supabase/auth/email/recovery.html
+++ b/supabase/auth/email/recovery.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Reset Your Password</title>
+</head>
+<body>
+  <h2>Reset Your Password</h2>
+  <p>Somebody requested a password reset for your Afromelody account. If this was you, click the link below to reset your password.</p>
+  <p>
+    <a href="{{ .ConfirmationURL }}">Reset password</a>
+  </p>
+</body>
+</html>

--- a/supabase/auth/email/signup.html
+++ b/supabase/auth/email/signup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Confirm Your Signup</title>
+</head>
+<body>
+  <h2>Confirm your signup</h2>
+  <p>Thanks for signing up for Afromelody! Click the link below to confirm your email address.</p>
+  <p>
+    <a href="{{ .ConfirmationURL }}">Confirm your email</a>
+  </p>
+</body>
+</html>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,8 @@
 project_id = "bswfiynuvjvoaoyfdrso"
+
+[auth.email]
+template.signup = "/auth/email/signup.html"
+template.invite = "/auth/email/invite.html"
+template.magic_link = "/auth/email/magic_link.html"
+template.recovery = "/auth/email/recovery.html"
+template.email_change = "/auth/email/email_change.html"


### PR DESCRIPTION
This commit introduces custom email templates for Supabase authentication. The new templates are branded with the site name "Afromelody" to provide a more consistent user experience.

The following templates have been added:
- signup.html
- invite.html
- magic_link.html
- recovery.html
- email_change.html

The `supabase/config.toml` file has been updated to use these new templates.