### PR TITLE
refactor: Remove admin redirect from user dashboard

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -2,45 +2,49 @@
 import { Outlet } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Sidebar from "@/components/Sidebar";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { AudioPlayerProvider } from "@/contexts/AudioPlayerContext";
 import { AudioPlayer } from "@/components/AudioPlayer";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
-
-const AppLayoutContent = () => {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  return (
-    <div className="h-screen flex flex-col bg-black text-white font-sans">
-      <div className="flex flex-1">
-        {/* Desktop Sidebar */}
-        <div className="hidden md:block flex-shrink-0 w-24">
-          <Sidebar className="bg-black border-r border-white/10" />
-        </div>
-
-        <div className="flex-1 flex flex-col">
-          <Navbar onMenuClick={() => setSidebarOpen(true)} />
-          <main className="flex-1 overflow-y-auto">
-            <Outlet />
-          </main>
-        </div>
-      </div>
-      <AudioPlayer />
-
-      {/* Mobile Sidebar */}
-      <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-        <SheetContent side="left" className="w-24 p-0 flex flex-col bg-black border-r border-white/10">
-          <Sidebar />
-        </SheetContent>
-      </Sheet>
-    </div>
-  );
-};
+import { useAuth } from "@/contexts/AuthContext";
+import { toast } from "sonner";
 
 const AppLayout = () => {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { user, isAdmin, isSuperAdmin, signOut } = useAuth();
+
+  useEffect(() => {
+    if (user && (isAdmin() || isSuperAdmin())) {
+      toast.error("Admins are not allowed in the user dashboard. Please use the admin login.");
+      signOut();
+    }
+  }, [user, isAdmin, isSuperAdmin, signOut]);
+
   return (
     <AudioPlayerProvider>
-      <AppLayoutContent />
+      <div className="h-screen flex flex-col bg-black text-white font-sans">
+        <div className="flex flex-1">
+          {/* Desktop Sidebar */}
+          <div className="hidden md:block flex-shrink-0 w-24">
+            <Sidebar className="bg-black border-r border-white/10" />
+          </div>
+
+          <div className="flex-1 flex flex-col">
+            <Navbar onMenuClick={() => setSidebarOpen(true)} />
+            <main className="flex-1 overflow-y-auto">
+              <Outlet />
+            </main>
+          </div>
+        </div>
+        <AudioPlayer />
+
+        {/* Mobile Sidebar */}
+        <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+          <SheetContent side="left" className="w-24 p-0 flex flex-col bg-black border-r border-white/10">
+            <Sidebar />
+          </SheetContent>
+        </Sheet>
+      </div>
     </AudioPlayerProvider>
   );
 };


### PR DESCRIPTION
This commit updates the admin check in the main application layout.

Based on user feedback, the automatic redirect to the admin login page has been removed. Now, when an admin user signs in through the user-facing Google login, they will be immediately signed out and shown a 'not allowed' message, but they will not be redirected. They must manually navigate to the admin login page.

This change aligns the functionality with the specific user requirement.