### PR TITLE
feat: Implement Google-only auth and block admin login

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -232,14 +232,22 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
               if (userData && mounted) {
                 const roles = await fetchUserRoles(currentSession.user.id);
                 const winnerStatus = await checkIsWinner(currentSession.user.id);
-                setUser(userData);
-                setUserRoles(roles);
-                setIsWinner(winnerStatus);
-                console.log("AuthContext: User data and roles set", { 
-                  userData: { id: userData.id, email: userData.email }, 
-                  roles,
-                  isWinner: winnerStatus,
-                });
+
+                if (roles.includes('admin') || roles.includes('super_admin')) {
+                  console.log("AuthContext: Admin user detected during login. Signing out.");
+                  toast.error("Admins must use the dedicated admin login page.");
+                  await supabase.auth.signOut();
+                  // The onAuthStateChange listener will handle state cleanup
+                } else {
+                  setUser(userData);
+                  setUserRoles(roles);
+                  setIsWinner(winnerStatus);
+                  console.log("AuthContext: User data and roles set", {
+                    userData: { id: userData.id, email: userData.email },
+                    roles,
+                    isWinner: winnerStatus,
+                  });
+                }
               } else {
                 console.error(`User profile not found for ID: ${currentSession.user.id}`);
                 setUser(null);
@@ -289,9 +297,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             if (userData && mounted) {
               const roles = await fetchUserRoles(currentSession.user.id);
               const winnerStatus = await checkIsWinner(currentSession.user.id);
-              setUser(userData);
-              setUserRoles(roles);
-              setIsWinner(winnerStatus);
+              if (roles.includes('admin') || roles.includes('super_admin')) {
+                console.log("AuthContext: Admin user detected in initial session. Signing out.");
+                await supabase.auth.signOut();
+              } else {
+                setUser(userData);
+                setUserRoles(roles);
+                setIsWinner(winnerStatus);
+              }
             }
           } catch (error) {
             console.error('Error fetching initial user data:', error);

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -2,23 +2,13 @@
 import { Outlet } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Sidebar from "@/components/Sidebar";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { AudioPlayerProvider } from "@/contexts/AudioPlayerContext";
 import { AudioPlayer } from "@/components/AudioPlayer";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
-import { useAuth } from "@/contexts/AuthContext";
-import { toast } from "sonner";
 
 const AppLayout = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const { user, isAdmin, isSuperAdmin, signOut } = useAuth();
-
-  useEffect(() => {
-    if (user && (isAdmin() || isSuperAdmin())) {
-      toast.error("Admins are not allowed in the user dashboard. Please use the admin login.");
-      signOut();
-    }
-  }, [user, isAdmin, isSuperAdmin, signOut]);
 
   return (
     <AudioPlayerProvider>


### PR DESCRIPTION
This commit refactors the authentication flow to make Google the sole method for user login and registration, and enhances security by preventing administrators from using the user-facing login.

Key changes:
- The login, registration, and forgot password pages have been consolidated into a single authentication page at `/login`.
- The `/register` and `/forgot-password` routes now redirect to `/login`.
- The UI presents a single "Continue with Google" button, with a mandatory "Terms and Conditions" checkbox.
- A robust security check has been added to the `AuthContext` to verify user roles immediately upon authentication.
- If a user with an 'admin' or 'super_admin' role attempts to sign in via the user portal, they are immediately signed out and notified that they must use the dedicated admin login.
- This prevents admins from accessing the user dashboard and resolves the timing issue present in previous attempts.