### PR TITLE
feat: Add contest submission types and social links

### DIFF
--- a/src/components/admin/ContestManagement.tsx
+++ b/src/components/admin/ContestManagement.tsx
@@ -32,6 +32,14 @@ import {
 import { supabase } from '@/integrations/supabase/client';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from '@/components/ui/textarea';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -116,6 +124,8 @@ export const ContestManagement = () => {
     end_date: null as Date | null,
     instrumental_url: '',
     entry_fee: 0,
+    submission_type: 'library' as 'library' | 'genre_template',
+    social_link_enabled: false,
   });
 
   // Reset form
@@ -129,6 +139,8 @@ export const ContestManagement = () => {
       end_date: null,
       instrumental_url: '',
       entry_fee: 0,
+      submission_type: 'library',
+      social_link_enabled: false,
     });
     setInstrumentalFile(null);
   };
@@ -324,6 +336,8 @@ export const ContestManagement = () => {
       end_date: new Date(contest.end_date),
       instrumental_url: contest.instrumental_url || '',
       entry_fee: contest.entry_fee || 0,
+      submission_type: (contest as any).submission_type || 'library',
+      social_link_enabled: (contest as any).social_link_enabled || false,
     });
     setIsEditDialogOpen(true);
   };
@@ -370,9 +384,11 @@ export const ContestManagement = () => {
         end_date: formatDateForSubmission(contestForm.end_date)!,
         instrumental_url: instrumentalUrl,
         entry_fee: contestForm.entry_fee || 0,
+        submission_type: contestForm.submission_type,
+        social_link_enabled: contestForm.social_link_enabled,
       };
 
-      const success = await createContest(contestData);
+      const success = await createContest(contestData as any);
       if (success) {
         setIsCreateDialogOpen(false);
         resetForm();
@@ -426,9 +442,11 @@ export const ContestManagement = () => {
         end_date: formatDateForSubmission(contestForm.end_date)!,
         instrumental_url: instrumentalUrl,
         entry_fee: contestForm.entry_fee || 0,
+        submission_type: contestForm.submission_type,
+        social_link_enabled: contestForm.social_link_enabled,
       };
 
-      const success = await updateContest(selectedContest.id, contestData);
+      const success = await updateContest(selectedContest.id, contestData as any);
       if (success) {
         setIsEditDialogOpen(false);
         setSelectedContest(null);
@@ -1015,6 +1033,39 @@ export const ContestManagement = () => {
                 The number of credits required to enter. Set to 0 for free entry.
               </p>
             </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Submission Type</Label>
+                <Select
+                  value={contestForm.submission_type}
+                  onValueChange={(value) =>
+                    setContestForm({ ...contestForm, submission_type: value as 'library' | 'genre_template' })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select submission type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="library">From User Library</SelectItem>
+                    <SelectItem value="genre_template">From Genre Templates</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col gap-2 pt-2">
+                <Label>Enable Social Link</Label>
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    checked={contestForm.social_link_enabled}
+                    onCheckedChange={(checked) =>
+                      setContestForm({ ...contestForm, social_link_enabled: checked })
+                    }
+                  />
+                  <Label htmlFor="social-link-switch" className="text-sm font-medium">
+                    {contestForm.social_link_enabled ? "Enabled" : "Disabled"}
+                  </Label>
+                </div>
+              </div>
+            </div>
           </div>
           
           <DialogFooter>
@@ -1195,6 +1246,39 @@ export const ContestManagement = () => {
               <p className="text-xs text-muted-foreground mt-1">
                 The number of credits required to enter. Set to 0 for free entry.
               </p>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Submission Type</Label>
+                <Select
+                  value={contestForm.submission_type}
+                  onValueChange={(value) =>
+                    setContestForm({ ...contestForm, submission_type: value as 'library' | 'genre_template' })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select submission type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="library">From User Library</SelectItem>
+                    <SelectItem value="genre_template">From Genre Templates</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col gap-2 pt-2">
+                <Label>Enable Social Link</Label>
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    checked={contestForm.social_link_enabled}
+                    onCheckedChange={(checked) =>
+                      setContestForm({ ...contestForm, social_link_enabled: checked })
+                    }
+                  />
+                  <Label htmlFor="social-link-switch" className="text-sm font-medium">
+                    {contestForm.social_link_enabled ? "Enabled" : "Disabled"}
+                  </Label>
+                </div>
+              </div>
             </div>
           </div>
           

--- a/src/components/contest/SubmissionDialog.tsx
+++ b/src/components/contest/SubmissionDialog.tsx
@@ -4,10 +4,13 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
 import { useContestSubmission } from '@/hooks/useContestSubmission';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
+import { useGenreTemplates, GenreTemplate } from '@/hooks/use-genre-templates';
+import { Contest } from '@/hooks/use-contest';
 
 interface Song {
   id: string;
@@ -17,22 +20,25 @@ interface Song {
 interface SubmissionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  contestId: string;
+  contest: Contest;
   onSubmissionSuccess: () => void;
 }
 
-export const SubmissionDialog = ({ open, onOpenChange, contestId, onSubmissionSuccess }: SubmissionDialogProps) => {
+export const SubmissionDialog = ({ open, onOpenChange, contest, onSubmissionSuccess }: SubmissionDialogProps) => {
   const { user } = useAuth();
   const { submitEntry, isSubmitting } = useContestSubmission();
+  const { templates: genreTemplates, loading: templatesLoading } = useGenreTemplates();
   const [songs, setSongs] = useState<Song[]>([]);
   const [selectedSong, setSelectedSong] = useState<string>('');
+  const [selectedGenreTemplate, setSelectedGenreTemplate] = useState<string>('');
   const [description, setDescription] = useState('');
+  const [socialLink, setSocialLink] = useState('');
 
   useEffect(() => {
-    if (user && open) {
+    if (user && open && contest.submission_type === 'library') {
       fetchUserSongs();
     }
-  }, [user, open]);
+  }, [user, open, contest.submission_type]);
 
   const fetchUserSongs = async () => {
     if (!user) return;
@@ -53,15 +59,22 @@ export const SubmissionDialog = ({ open, onOpenChange, contestId, onSubmissionSu
   };
 
   const handleSubmit = async () => {
-    if (!selectedSong) {
+    if (contest.submission_type === 'library' && !selectedSong) {
       toast.error('Please select a song to submit.');
       return;
     }
+    if (contest.submission_type === 'genre_template' && !selectedGenreTemplate) {
+      toast.error('Please select a genre template to submit.');
+      return;
+    }
+
     try {
       await submitEntry({
-        contestId,
+        contestId: contest.id,
         songId: selectedSong,
+        genreTemplateId: selectedGenreTemplate,
         description,
+        socialLink,
       });
       onSubmissionSuccess();
       onOpenChange(false);
@@ -70,39 +83,80 @@ export const SubmissionDialog = ({ open, onOpenChange, contestId, onSubmissionSu
     }
   };
 
+  const isSubmitDisabled = () => {
+    if (isSubmitting) return true;
+    if (contest.submission_type === 'library') {
+      return !selectedSong;
+    }
+    if (contest.submission_type === 'genre_template') {
+      return !selectedGenreTemplate;
+    }
+    return true;
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px] bg-gray-900 border-white/10 text-white">
         <DialogHeader>
-          <DialogTitle>Submit to Contest</DialogTitle>
+          <DialogTitle>Submit to {contest.title}</DialogTitle>
           <DialogDescription className="text-gray-400">
-            Choose a song and add a description for your entry.
+            {contest.submission_type === 'library'
+              ? 'Choose one of your songs to enter the contest.'
+              : 'Choose a genre template to create your entry.'}
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
-          <div className="grid grid-cols-4 items-center gap-4">
-            <Label htmlFor="song" className="text-right text-gray-300">
-              Song
-            </Label>
-            <Select value={selectedSong} onValueChange={setSelectedSong}>
-              <SelectTrigger className="col-span-3 bg-black/20 border-white/20">
-                <SelectValue placeholder="Select a song" />
-              </SelectTrigger>
-              <SelectContent>
-                {songs.length > 0 ? (
-                  songs.map((song) => (
-                    <SelectItem key={song.id} value={song.id}>
-                      {song.title}
+          {contest.submission_type === 'library' ? (
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="song" className="text-right text-gray-300">
+                Song
+              </Label>
+              <Select value={selectedSong} onValueChange={setSelectedSong}>
+                <SelectTrigger className="col-span-3 bg-black/20 border-white/20">
+                  <SelectValue placeholder="Select a song" />
+                </SelectTrigger>
+                <SelectContent>
+                  {songs.length > 0 ? (
+                    songs.map((song) => (
+                      <SelectItem key={song.id} value={song.id}>
+                        {song.title}
+                      </SelectItem>
+                    ))
+                  ) : (
+                    <SelectItem value="no-songs" disabled>
+                      No completed songs found.
                     </SelectItem>
-                  ))
-                ) : (
-                  <SelectItem value="no-songs" disabled>
-                    No completed songs found.
-                  </SelectItem>
-                )}
-              </SelectContent>
-            </Select>
-          </div>
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="genre-template" className="text-right text-gray-300">
+                Genre
+              </Label>
+              <Select value={selectedGenreTemplate} onValueChange={setSelectedGenreTemplate}>
+                <SelectTrigger className="col-span-3 bg-black/20 border-white/20">
+                  <SelectValue placeholder="Select a genre template" />
+                </SelectTrigger>
+                <SelectContent>
+                  {templatesLoading ? (
+                     <SelectItem value="loading" disabled>Loading templates...</SelectItem>
+                  ) : genreTemplates.length > 0 ? (
+                    genreTemplates.map((template) => (
+                      <SelectItem key={template.id} value={template.id}>
+                        {template.template_name}
+                      </SelectItem>
+                    ))
+                  ) : (
+                    <SelectItem value="no-templates" disabled>
+                      No genre templates available.
+                    </SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="description" className="text-right text-gray-300">
               Description
@@ -115,12 +169,26 @@ export const SubmissionDialog = ({ open, onOpenChange, contestId, onSubmissionSu
               placeholder="Tell us about your entry (optional)"
             />
           </div>
+          {contest.social_link_enabled && (
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="social-link" className="text-right text-gray-300">
+                Social Link
+              </Label>
+              <Input
+                id="social-link"
+                value={socialLink}
+                onChange={(e) => setSocialLink(e.target.value)}
+                className="col-span-3 bg-black/20 border-white/20"
+                placeholder="e.g., soundcloud.com/artist"
+              />
+            </div>
+          )}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting} className="bg-transparent border-white/30 hover:bg-white/10">
             Cancel
           </Button>
-          <Button onClick={handleSubmit} disabled={isSubmitting || !selectedSong} className="bg-dark-purple hover:bg-opacity-90 font-bold">
+          <Button onClick={handleSubmit} disabled={isSubmitDisabled()} className="bg-dark-purple hover:bg-opacity-90 font-bold">
             {isSubmitting ? 'Submitting...' : 'Submit Entry'}
           </Button>
         </DialogFooter>

--- a/src/hooks/use-contest.ts
+++ b/src/hooks/use-contest.ts
@@ -24,6 +24,8 @@ export interface Contest {
   created_at: string;
   entry_fee: number;
   is_unlocked?: boolean;
+  submission_type: 'library' | 'genre_template';
+  social_link_enabled: boolean;
 }
 
 export interface ContestEntry {
@@ -37,6 +39,7 @@ export interface ContestEntry {
   vote_count: number;
   media_type: string;
   created_at: string;
+  social_link?: string;
   profiles?: {
     full_name: string;
     username: string;
@@ -168,6 +171,8 @@ export const useContest = () => {
     end_date: string;
     instrumental_url: string;
     entry_fee: number;
+    submission_type: 'library' | 'genre_template';
+    social_link_enabled: boolean;
   }) => {
     if (!user) {
       toast.error('Please log in to create contests');
@@ -213,6 +218,8 @@ export const useContest = () => {
     end_date: string;
     instrumental_url: string;
     entry_fee: number;
+    submission_type: 'library' | 'genre_template';
+    social_link_enabled: boolean;
   }) => {
     if (!user) {
       toast.error('Please log in to update contests');

--- a/src/hooks/useContestSubmission.ts
+++ b/src/hooks/useContestSubmission.ts
@@ -6,7 +6,9 @@ import { toast } from 'sonner';
 interface ContestSubmissionData {
   contestId: string;
   songId?: string;
+  genreTemplateId?: string;
   description?: string;
+  socialLink?: string;
 }
 
 export const useContestSubmission = () => {
@@ -42,8 +44,10 @@ export const useContestSubmission = () => {
         contest_id: data.contestId,
         user_id: user.id,
         song_id: data.songId || null,
+        genre_template_id: data.genreTemplateId || null,
         video_url: null,
         description: data.description || null,
+        social_link: data.socialLink || null,
         status: 'pending' as const,
         approved: false,
         media_type: 'audio' as const

--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -520,6 +520,16 @@ const PastContestCard = ({ contest }: { contest: ContestType }) => {
                               </div>
                               <div className="flex items-center gap-4">
                                 <div className="flex items-center gap-2 text-sm text-white"><Vote className="h-4 w-4 text-dark-purple" /><span>{entry.vote_count}</span></div>
+                                {entry.social_link && (
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => window.open(entry.social_link, '_blank')}
+                                    className="bg-transparent border-white/30 hover:bg-white/10 text-white"
+                                  >
+                                    View
+                                  </Button>
+                                )}
                                 <Button variant="outline" size="sm" onClick={() => handleVoteClick(entry)} disabled={isVoting} className="bg-transparent border-white/30 hover:bg-white/10 text-white">
                                   Vote
                                 </Button>
@@ -569,7 +579,7 @@ const PastContestCard = ({ contest }: { contest: ContestType }) => {
         <SubmissionDialog
           open={submissionDialogOpen}
           onOpenChange={setSubmissionDialogOpen}
-          contestId={selectedContest.id}
+          contest={selectedContest}
           onSubmissionSuccess={() => {
             toast.success('Your entry has been submitted for review.');
             refreshEntries();

--- a/supabase/migrations/20250918071900_add_contest_submission_types.sql
+++ b/supabase/migrations/20250918071900_add_contest_submission_types.sql
@@ -1,0 +1,15 @@
+-- Add submission_type to contests table
+ALTER TABLE public.contests
+ADD COLUMN submission_type TEXT NOT NULL DEFAULT 'library' CHECK (submission_type IN ('library', 'genre_template'));
+
+-- Add social_link_enabled to contests table
+ALTER TABLE public.contests
+ADD COLUMN social_link_enabled BOOLEAN NOT NULL DEFAULT false;
+
+-- Add social_link to contest_entries table
+ALTER TABLE public.contest_entries
+ADD COLUMN social_link TEXT;
+
+-- Add genre_template_id to contest_entries table
+ALTER TABLE public.contest_entries
+ADD COLUMN genre_template_id UUID REFERENCES public.genre_templates(id);


### PR DESCRIPTION
This commit introduces a new feature that allows for two types of contest submissions: from a user's personal library or from a list of genre templates.

Key changes:
- Added `submission_type` and `social_link_enabled` columns to the `contests` table.
- Added `social_link` and `genre_template_id` columns to the `contest_entries` table.
- Updated the admin contest creation form to include options for submission type and enabling social links.
- Modified the contest submission dialog to conditionally render the form based on the contest's submission type.
- Added a "View" button to contest entries to open the provided social media link.