### PR TITLE
feat: Update contest entry display and add instrumental download

### DIFF
--- a/src/components/music-generation/MusicGenerationWorkflow.tsx
+++ b/src/components/music-generation/MusicGenerationWorkflow.tsx
@@ -151,6 +151,7 @@ export const MusicGenerationWorkflow = ({ preSelectedGenre, initialPrompt, templ
         customMode: false,
         instrumental,
         model: apiModelName,
+        templateId: templateData?.id,
       };
     } else { // lyrics mode
       request = {
@@ -160,6 +161,7 @@ export const MusicGenerationWorkflow = ({ preSelectedGenre, initialPrompt, templ
         title: title,
         style: adminPrompt,
         model: apiModelName,
+        templateId: templateData?.id,
       };
     }
 

--- a/src/hooks/use-contest.ts
+++ b/src/hooks/use-contest.ts
@@ -47,6 +47,9 @@ export interface ContestEntry {
   songs?: {
     title: string;
     audio_url: string;
+    genre_templates?: {
+      template_name: string;
+    } | null;
   } | null;
 }
 
@@ -321,7 +324,13 @@ export const useContest = () => {
         .from('contest_entries')
         .select(`
           *,
-          songs (title, audio_url)
+          songs (
+            title,
+            audio_url,
+            genre_templates (
+              template_name
+            )
+          )
         `)
         .eq('contest_id', contestId)
         .eq('approved', true)

--- a/src/hooks/use-suno-generation.ts
+++ b/src/hooks/use-suno-generation.ts
@@ -11,6 +11,7 @@ export interface SunoGenerationRequest {
   title?: string;
   style?: string;
   model: 'V3_5' | 'V4' | 'V4_5';
+  templateId?: string;
 }
 
 export const getModelDisplayName = (apiModel: string): string => {

--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -40,6 +40,7 @@ const Contest = () => {
     unlockContest,
     submitting,
     setCurrentContest,
+    downloadInstrumental,
   } = useContest();
   const { currentTrack, isPlaying, playTrack, togglePlayPause } = useAudioPlayer();
   const [songs, setSongs] = useState<Song[]>([]);
@@ -315,7 +316,7 @@ const PastContestCard = ({ contest }: { contest: ContestType }) => {
     if (announcementDate && now < announcementDate) {
       return (
         <div className="text-center py-6 text-gray-400">
-          <p>Winners will be announced on {announcementDate.toLocaleDateString()}.</p>
+          <p>Winners will be announced on {announcementDate.toLocaleDateString()}.p>
         </div>
       );
     }
@@ -403,9 +404,20 @@ const PastContestCard = ({ contest }: { contest: ContestType }) => {
                       </div>
                       <div className="flex items-center gap-4">
                         {contest.is_unlocked ? (
-                          <Button size="sm" className="bg-dark-purple hover:bg-opacity-90 font-bold" onClick={() => openSubmissionDialog(contest)}>
-                            Submit Entry
-                          </Button>
+                          <div className="flex items-center gap-2">
+                            <Button size="sm" className="bg-dark-purple hover:bg-opacity-90 font-bold" onClick={() => openSubmissionDialog(contest)}>
+                              Submit Entry
+                            </Button>
+                            {contest.instrumental_url && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => downloadInstrumental(contest.instrumental_url!, contest.title)}
+                              >
+                                Download Instrumental
+                              </Button>
+                            )}
+                          </div>
                         ) : (
                           <Button size="sm" onClick={() => handleUnlockContest(contest)} disabled={submitting || (user?.credits ?? 0) < contest.entry_fee}>
                             {submitting ? 'Unlocking...' : `Unlock for ${contest.entry_fee} credits`}
@@ -511,9 +523,17 @@ const PastContestCard = ({ contest }: { contest: ContestType }) => {
                           .filter(e => e.profiles?.full_name.toLowerCase().includes(searchTerm.toLowerCase()))
                           .map((entry) => (
                             <div key={entry.id} className="flex items-center p-3 rounded-lg bg-white/5 hover:bg-white/10 transition-colors flex-wrap">
-                               <Button variant="ghost" size="icon" onClick={() => handlePlay(entry)} className="text-gray-300 hover:text-white">
-                                 {currentTrack?.id === entry.id && isPlaying ? <Pause className="h-5 w-5 text-dark-purple" /> : <Play className="h-5 w-5" />}
-                               </Button>
+                               {currentContest?.submission_type === 'genre_template' ? (
+                                <div className="w-10 h-10 flex items-center justify-center">
+                                  <span className="text-xs text-center text-muted-foreground">
+                                    ({entry.songs?.genre_templates?.template_name || 'Genre'} - {currentContest.title})
+                                  </span>
+                                </div>
+                              ) : (
+                                <Button variant="ghost" size="icon" onClick={() => handlePlay(entry)} className="text-gray-300 hover:text-white">
+                                  {currentTrack?.id === entry.id && isPlaying ? <Pause className="h-5 w-5 text-dark-purple" /> : <Play className="h-5 w-5" />}
+                                </Button>
+                              )}
                                <div className="flex-grow mx-4 min-w-0">
                                  <p className="font-semibold truncate">{entry.songs?.title ?? 'Untitled Song'}</p>
                                 <p className="text-sm text-gray-400">By {entry.profiles?.full_name || 'Unknown Artist'}</p>

--- a/supabase/functions/suno-generate/index.ts
+++ b/supabase/functions/suno-generate/index.ts
@@ -47,11 +47,13 @@ Deno.serve(async (req) => {
       model = 'V3_5',
       negativeTags,
       userId,
-      isAdminTest = false
+      isAdminTest = false,
+      templateId
     } = body
 
     console.log('📥 Generation request received:', {
       userId,
+      templateId,
       prompt: prompt?.substring(0, 100) + '...',
       style,
       title,
@@ -324,7 +326,8 @@ Deno.serve(async (req) => {
       prompt,
       status: 'pending',
       credits_used: isAdminTest ? 0 : 20,
-      task_id: taskId
+      task_id: taskId,
+      template_id: templateId || null
     }
 
     console.log('💾 Creating song record with data:', songData)

--- a/supabase/migrations/20250919220000_add_template_id_to_songs.sql
+++ b/supabase/migrations/20250919220000_add_template_id_to_songs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE songs
+ADD COLUMN template_id UUID REFERENCES genre_templates(id) ON DELETE SET NULL;


### PR DESCRIPTION
- If a contest is configured to use genre templates, the entry display now shows the genre template name and contest title instead of a play icon.
- For contests with an attached instrumental, a download button now appears after a user unlocks the contest.
- Adds a `template_id` to the `songs` table to link songs to genre templates.
- Updates the song generation flow to save the `template_id`.
- Updates the contest entry query to fetch the `template_name`.