### PR TITLE
Fix contest entry title for genre template submissions

### DIFF
--- a/src/hooks/use-contest.ts
+++ b/src/hooks/use-contest.ts
@@ -40,6 +40,7 @@ export interface ContestEntry {
   media_type: string;
   created_at: string;
   social_link?: string;
+  genre_template_id?: string;
   profiles?: {
     full_name: string;
     username: string;
@@ -47,6 +48,9 @@ export interface ContestEntry {
   songs?: {
     title: string;
     audio_url: string;
+  } | null;
+  genre_templates?: {
+    name: string;
   } | null;
 }
 
@@ -321,7 +325,8 @@ export const useContest = () => {
         .from('contest_entries')
         .select(`
           *,
-          songs (title, audio_url)
+          songs (title, audio_url),
+          genre_templates (name)
         `)
         .eq('contest_id', contestId)
         .eq('approved', true)

--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -523,17 +523,15 @@ const PastContestCard = ({ contest }: { contest: ContestType }) => {
                           .filter(e => e.profiles?.full_name.toLowerCase().includes(searchTerm.toLowerCase()))
                           .map((entry) => (
                             <div key={entry.id} className="flex items-center p-3 rounded-lg bg-white/5 hover:bg-white/10 transition-colors flex-wrap">
-                               {c.submission_type === 'genre_template' ? (
-                                <div className="w-10 h-10 flex items-center justify-center">
-                                  <span className="text-xs text-center text-muted-foreground">({entry.songs?.title || 'Genre'} - {c.title})</span>
-                                </div>
-                              ) : (
                                  <Button variant="ghost" size="icon" onClick={() => handlePlay(entry)} className="text-gray-300 hover:text-white">
                                    {currentTrack?.id === entry.id && isPlaying ? <Pause className="h-5 w-5 text-dark-purple" /> : <Play className="h-5 w-5" />}
                                  </Button>
-                               )}
                                <div className="flex-grow mx-4 min-w-0">
-                                 <p className="font-semibold truncate">{entry.songs?.title ?? 'Untitled Song'}</p>
+                                 <p className="font-semibold truncate">
+                                   {c.submission_type === 'genre_template' && entry.genre_templates?.name
+                                     ? `${entry.genre_templates.name} (${c.title})`
+                                     : entry.songs?.title ?? 'Untitled Song'}
+                                 </p>
                                 <p className="text-sm text-gray-400">By {entry.profiles?.full_name || 'Unknown Artist'}</p>
                               </div>
                               <div className="flex items-center gap-4">


### PR DESCRIPTION
- For contest entries that are submissions from a genre template, the title is now displayed as "genre template name (contest name)".
- The "(Genre - contest name)" text that was displayed next to the play button for these entries has been removed.
- The play button is now displayed for all contest entries.