### PR TITLE
Fix(contest): Correct contest entry display for genre templates

### DIFF
--- a/src/hooks/use-contest.ts
+++ b/src/hooks/use-contest.ts
@@ -48,6 +48,9 @@ export interface ContestEntry {
     title: string;
     audio_url: string;
   } | null;
+  genre_templates?: {
+    template_name: string;
+  } | null;
 }
 
 export const useContest = () => {
@@ -321,7 +324,8 @@ export const useContest = () => {
         .from('contest_entries')
         .select(`
           *,
-          songs (title, audio_url)
+          songs (title, audio_url),
+          genre_templates (template_name)
         `)
         .eq('contest_id', contestId)
         .eq('approved', true)

--- a/src/pages/Contest.tsx
+++ b/src/pages/Contest.tsx
@@ -524,16 +524,18 @@ const PastContestCard = ({ contest }: { contest: ContestType }) => {
                           .map((entry) => (
                             <div key={entry.id} className="flex items-center p-3 rounded-lg bg-white/5 hover:bg-white/10 transition-colors flex-wrap">
                                {c.submission_type === 'genre_template' ? (
-                                <div className="w-10 h-10 flex items-center justify-center">
-                                  <span className="text-xs text-center text-muted-foreground">({entry.songs?.title || 'Genre'} - {c.title})</span>
-                                </div>
-                              ) : (
+                                <div className="w-10 h-10" />
+                               ) : (
                                  <Button variant="ghost" size="icon" onClick={() => handlePlay(entry)} className="text-gray-300 hover:text-white">
                                    {currentTrack?.id === entry.id && isPlaying ? <Pause className="h-5 w-5 text-dark-purple" /> : <Play className="h-5 w-5" />}
                                  </Button>
                                )}
                                <div className="flex-grow mx-4 min-w-0">
-                                 <p className="font-semibold truncate">{entry.songs?.title ?? 'Untitled Song'}</p>
+                                 <p className="font-semibold truncate">
+                                   {c.submission_type === 'genre_template' && entry.genre_templates
+                                     ? `${entry.genre_templates.template_name} (contest)`
+                                     : entry.songs?.title ?? 'Untitled Song'}
+                                 </p>
                                 <p className="text-sm text-gray-400">By {entry.profiles?.full_name || 'Unknown Artist'}</p>
                               </div>
                               <div className="flex items-center gap-4">


### PR DESCRIPTION
This commit fixes two issues with the display of contest entries that are based on a genre template:

1. The entry title is now correctly displayed as "[Genre Template Name] (contest)" instead of "Untitled Song".
2. The play button is now correctly hidden for these entries, as they do not have an associated audio file.