### PR TITLE
fix: Correct Flutterwave payment fulfillment logic

### DIFF
--- a/supabase/functions/verify-flw/index.ts
+++ b/supabase/functions/verify-flw/index.ts
@@ -77,21 +77,21 @@ serve(async (req) => {
     // 5. Give value to the user
     if (type === 'credits') {
       const { error } = await supabaseAdmin.rpc('update_user_credits', {
-        user_id_param: user_id,
-        credits_change: credits,
+        p_user_id: user_id,
+        p_amount: credits,
       });
       if (error) throw new Error(`Failed to update user credits: ${error.message}`);
     } else if (type === 'subscription') {
       // Logic to update subscription status
       const { error } = await supabaseAdmin
         .from('subscriptions')
-        .update({
+        .upsert({
+          user_id: user_id,
           status: 'active',
           plan_id: plan_id,
           gateway: 'flutterwave',
           gateway_subscription_id: `flw_${result.data.id}`
-        })
-        .eq('user_id', user_id);
+        }, { onConflict: 'user_id' });
       if (error) throw new Error(`Failed to update subscription: ${error.message}`);
     }
 


### PR DESCRIPTION
This commit addresses two issues in the Flutterwave payment processing flow:

1.  **Subscription updates:** The webhook and verification functions were using a database `update` operation for subscriptions. This failed for new subscribers as no record existed to be updated. This has been changed to an `upsert` operation to correctly handle both new and existing subscriptions.

2.  **Credit purchases:** The `update_user_credits` RPC was being called with incorrect parameter names (`user_id_param`, `credits_change` instead of `p_user_id`, `p_amount`), causing credit top-ups to fail. The parameter names have been corrected in both the webhook and verification functions.

These changes ensure that both subscription and credit purchases made via Flutterwave are correctly processed and reflected in the user's account.