### PR TITLE
Fix: Correct Flutterwave v3 Integration

### DIFF
--- a/src/hooks/useFlutterwave.tsx
+++ b/src/hooks/useFlutterwave.tsx
@@ -41,7 +41,7 @@ export function useFlutterwave({ onSuccess, onClose }: UseFlutterwaveProps) {
     try {
       const tx_ref = `txn_${payload.meta.type}_${user.id}_${Date.now()}`;
 
-      const modal = window.FlutterwaveCheckout?.({
+      window.FlutterwaveCheckout?.({
         public_key: payload.publicKey,
         tx_ref,
         amount: payload.amount,
@@ -54,21 +54,21 @@ export function useFlutterwave({ onSuccess, onClose }: UseFlutterwaveProps) {
         meta: payload.meta,
         customizations: payload.customizations,
         callback: async (payment: any) => {
-          // Close the modal immediately
-          modal?.close();
-
-          // Verify the transaction on the backend
-          const verificationResponse = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/verify-flw`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
-            },
-            body: JSON.stringify({
-              transaction_id: payment.transaction_id,
-              tx_ref: tx_ref,
-            }),
-          });
+          // Flutterwave closes the modal automatically
+          const verificationResponse = await fetch(
+            `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/verify-flw`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+              },
+              body: JSON.stringify({
+                transaction_id: payment.transaction_id,
+                tx_ref: tx_ref,
+              }),
+            }
+          );
 
           const verificationResult = await verificationResponse.json();
 
@@ -76,7 +76,8 @@ export function useFlutterwave({ onSuccess, onClose }: UseFlutterwaveProps) {
             onSuccess(verificationResult.data);
           } else {
             toast.error('Payment verification failed.', {
-              description: verificationResult.error?.message || 'Please contact support.',
+              description:
+                verificationResult.error?.message || 'Please contact support.',
             });
           }
         },

--- a/supabase/functions/flw-webhook/index.ts
+++ b/supabase/functions/flw-webhook/index.ts
@@ -24,11 +24,12 @@ serve(async (req) => {
 
     if (payload.event === 'charge.completed' && payload.data.status === 'successful') {
       const chargeData = payload.data;
-      const { id, amount, currency, metadata } = chargeData;
-      const { user_id, type, credits, plan_id, plan_name } = metadata;
+      const { id, amount, currency } = chargeData;
+      const meta = chargeData.meta || chargeData.metadata || {};
+      const { user_id, type, credits, plan_id, plan_name } = meta;
 
       if (!user_id) {
-        console.error('Flutterwave webhook error: No user_id in event metadata', metadata);
+        console.error('Flutterwave webhook error: No user_id in event metadata', meta);
         return new Response('No user_id in metadata', { status: 400, headers: corsHeaders });
       }
 

--- a/supabase/functions/verify-flw/index.ts
+++ b/supabase/functions/verify-flw/index.ts
@@ -24,7 +24,10 @@ serve(async (req) => {
 
     const verifyRes = await fetch(`https://api.flutterwave.com/v3/transactions/${transaction_id}/verify`, {
       method: "GET",
-      headers: { Authorization: `Bearer ${FLW_SECRET_KEY}` },
+      headers: {
+        Authorization: `Bearer ${FLW_SECRET_KEY}`,
+        "Content-Type": "application/json",
+      },
     });
     const result = await verifyRes.json();
 
@@ -39,8 +42,11 @@ serve(async (req) => {
       return new Response(JSON.stringify({ error: "tx_ref mismatch" }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });
     }
 
-    const { user_id, type, credits, plan_id, plan_name } = result.data.meta;
+    const meta = result.data.meta || result.data.metadata || {};
+    const { user_id, type, credits, plan_id, plan_name } = meta;
+
     if (!user_id) {
+      console.error("verify-flw: Missing user_id in metadata", meta);
       return new Response(JSON.stringify({ error: "Missing user_id in metadata" }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });
     }
 


### PR DESCRIPTION
This commit applies several fixes to the Flutterwave v3 integration to make it more robust and align with the official documentation.

The changes include:
- Removing the manual `modal.close()` call in the `useFlutterwave` hook, as the v3 API handles this automatically.
- Adding the `Content-Type` header to the backend verification API call for best practices.
- Implementing safer metadata handling in both the verification and webhook functions to account for potential inconsistencies in the key name (`meta` vs `metadata`).